### PR TITLE
Raincatcher 210 - build errors on a mac when installing raincatcher locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea/

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "4.14.0",
-    "fh-mbaas-api": "5.14.1",
+    "fh-mbaas-api": "5.14.2",
     "lodash": "4.7.0",
     "q": "1.4.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user",
-  "version": "0.0.23",
+  "version": "0.0.24-alpha.1",
   "description": "A user module for WFM",
   "main": "lib/angular/user-ng.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user",
-  "version": "0.0.24-alpha.1",
+  "version": "0.0.23",
   "description": "A user module for WFM",
   "main": "lib/angular/user-ng.js",
   "scripts": {


### PR DESCRIPTION
# Issue
Getting node-gyp build errors on a mac when installing raincatcher locally
Caused by dtrace-provider version used in older version of bunyan in `fh-mbaas-client`which was updated in latest `fh-mbaas-api`
# Solution
Update `fh-mbaas-api` to 5.14.2

# JIRA
https://issues.jboss.org/browse/RAINCATCH-210