### PR TITLE
Add password to request

### DIFF
--- a/lib/router/mbaas.js
+++ b/lib/router/mbaas.js
@@ -11,8 +11,9 @@ function initRouter(mediator) {
     var params = req.body; // params.userId params.password
     if (params && (params.userId || params.username)) {
       var username = params.userId || params.username;
+      var password = params.password;
       console.log('Checking credentials for user ' + username);
-      mediator.request('wfm:user:username:read', username)
+      mediator.request('wfm:user:username:read', username, password)
       .then(function(profileData) {
         console.log('Valid credentials for user ' + username);
         res.json({


### PR DESCRIPTION
User module needs to send the password from the request params on to the mediator. Currently it only includes username. Password is needed by any module that subscribes to the 'wfm:user:username:read' event so authentication can be correctly established.
