### PR TITLE
Raincatch-399 - User details passed back from the server should not include any password information.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,11 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true
   },
+  "parserOptions": {
+     "ecmaVersion": 6
+    },
   "extends": "eslint:recommended",
   "rules": {
     "array-callback-return": "warn",
@@ -31,4 +35,3 @@
     "localStorage": false
   }
 }
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install: npm install
 script:
   - npm test
   - nsp check
-  - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
+  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false
   slack:
@@ -22,4 +22,3 @@ notifications:
       secure: >-
         lX4k0NvpjlpspUez/Co2vaSca8ZqgpeYF/onEhQP75F4LIGMz3uY9w6orLZnbU6XwkoKIVW6BxFm8vhnxGxQu3R1QKI7GkbfNUw2tfh7sxdNBN+qvgpT3lUtCPm+u2kZxLGoWKnbPh+1XooIjR+p8JUR1tAIhhZKgx9d/fwFcfxVpj9ZXQbyVQT2RLQEJF6KrWuaYpzfHMVIqoKuv5QdjW7eqzg66lMcojuwk5oYnBUx8QyWHPpzSzRLEGAzO9Zod5OGbfme78/1wyjICO/Yj4GfMZ6Wz6SORVOooRmFTEX+BVQI2NiRAAaZNc5jwTPR1rdaohzk7V9VackJAAp6XGr6ksQuiushXzT/1Qy3MFPqevsFIx6rGm+gbUsuOiRnBs72ZYZGC3xoKx2tkbcCt40ol7GPY3nuu/Aj7Ll3kpLHW7A5oCF0k30FLXT1tmDq8dU5S9vrfDNgNLLY4kcejW5q5YT+Twhl2NWVDac5swC6LP2+QgdFejrKud03N/WhQv5TOgeowS8QVG7UR73zc0ryMRphACcbqdUDbktkrjHGo//CtYqlJ6cqZLHobPF+fKj05lXRLqkrnpHoJogVY8C0hzxQVW6dHRElZi9zq7dv69gWTaRxsMsuee+AQqqbkSbLCEKCjcRQqV6Wz93dnA4a1gfO0a6Ie25M15ZDsGI=
     on_pull_requests: false
-

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,10 +1,23 @@
+'use strict';
+
 module.exports = function(grunt) {
-  'use strict';
+  grunt.loadNpmTasks('grunt-mocha-test');
   grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
     eslint: {
       src: ["lib/**/*.js"]
+    },
+    mochaTest: {
+      test: {
+        options: {
+          run: true
+        },
+        src: ['**/*-spec.js']
+      }
     }
   });
+
   grunt.loadNpmTasks("grunt-eslint");
   grunt.registerTask('default', ['eslint']);
+  grunt.registerTask('unit', ['eslint','mochaTest']);
 };

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This module is packaged in a CommonJS format, exporting the name of the Angular 
 
 ```javascript
 angular.module('app', [
-, require('fh-wfm-user')
+  require('fh-wfm-user')
 ...
 ])
 ```
@@ -86,12 +86,17 @@ var express = require('express')
 // Set authServiveGuid
 var authServiceGuid = process.env.WFM_AUTH_GUID;
 
+// Choose which fields to remove from the user authentication response.
+var authResponseExclusionList = ['password'];
+
 // configure the express app
 ...
 
 // setup the wfm user router
-require('fh-wfm-user/lib/router/mbaas')(mediator, app);
+require('fh-wfm-user/lib/router/mbaas')(mediator, app, authResponseExclusionList);
 ```
+
+Note: Setting the `authResponseExclusionList` array as `['password', 'banner']` will prevent these fields from appearing in the authentication response. By default, the `password` field is removed from the response. To allow all fields to be sent, set `authResponseExclusionList` as an empty array.
 
 For a more complete example check [here](https://github.com/feedhenry-raincatcher/raincatcher-demo-auth)
 
@@ -114,13 +119,11 @@ Base url : `/api/wfm/[group|user|membership|`
 
 Base url : `/api/wfm/user`
 
-| resource | method | returns |
+| resource | method | returns | description |
 | -------- | ------ | ------- |
-| /auth | all | `{satus: 'ok', userId: username, sessionToken: sessiontoken, authResponse: profileData}` |
-| /verifysession | all | `{isValid: true}` |
-| /revokesession | all | `{}` |
-
-
+| /auth | all | `{status: 'ok', userId: username, sessionToken: sessiontoken, authResponse: authResponse}` | `sessionToken` : identifier for a specific user for the duration of that user's visit. <br>  `authResponse` : authentication response containing the authenticated users details. |
+| /verifysession | all | `{isValid: true}` | |
+| /revokesession | all | `{}` |  | |
 
 ### message data structure example
 - user :

--- a/lib/router/mbaas-spec.js
+++ b/lib/router/mbaas-spec.js
@@ -1,0 +1,61 @@
+var _ = require('lodash');
+const assert = require('assert');
+const authHandler = require('./mbaas');
+const sampleUserConfig = require('../../test/fixtures/sampleUserConfig.json');
+const sampleProfileData = require('../../test/fixtures/sampleUserProfile.json');
+const sampleProfileDataLength  = Object.keys(sampleProfileData).length;
+
+var sampleExclusionList1 = ['banner'];
+var sampleExclusionList2 = ['banner', 'avatar'];
+var sampleExclusionList3 = [];
+var sampleExclusionList4 = undefined;
+var sampleExclusionList5 = null;
+
+
+describe('Test Trimming The Authentication Response', function() {
+  describe('#testAuthResponseData', function() {
+    it('it should not remove any fields when an empty exclusion list is specified', function(done) {
+      var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList3);
+      assert(Object.keys(authResponse).length === sampleProfileDataLength, "Expect that specifying an empty exclusion list returns all the User fields in the response.");
+      done();
+    });
+    it('it should remove the password field by default', function(done) {
+      var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleUserConfig.authResponseExclusionList);
+      assert(authResponse.password === undefined, "Check that the Password field has been removed from the Response.");
+      assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that the auth response has a different length to the user profile data.");
+      done();
+    });
+    it('it should remove a single field when specified', function(done) {
+      var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList1);
+      assert(authResponse.banner === undefined, "Check that the Banner field has been removed from the Response.");
+      assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that the auth response has a different length to the user profile data.");
+      done();
+    });
+    it('it should remove a single field when specified and also not remove the password', function(done) {
+      var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList1);
+      assert(authResponse.banner === undefined, "Check that the Banner field has been removed from the Response.");
+      assert(authResponse.password !== undefined, "Check that the Password field has Not been removed from the Response.");
+      assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that the auth response has a different length to the user profile data.");
+      done();
+    });
+    it('it should remove a number of fields when specified', function(done) {
+      var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList2);
+      assert(authResponse.banner === undefined, "Check that the Banner field has been removed from the Response.");
+      assert(authResponse.avatar === undefined, "Check that the Avatar field has been removed from the Response.");
+      assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that the auth response has a different length to the user profile data.");
+      done();
+    });
+    it('it should return all fields when the exclusion list is undefined', function(done) {
+      var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList4);
+      assert(authResponse.password === undefined, "Check that the Password field has been removed from the Response.");
+      assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that specifying an undefined exclusion list will result in the default exclusion list being used");
+      done();
+    });
+    it('it should return all fields when the exclusion list is null', function(done) {
+      var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList5);
+      assert(authResponse.password === undefined, "Check that the Password field has been removed from the Response.");
+      assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that specifying a null exclusion list will result in the default exclusion list being used.");
+      done();
+    });
+  });
+});

--- a/lib/router/mbaas.js
+++ b/lib/router/mbaas.js
@@ -2,9 +2,10 @@
 
 var express = require('express')
   , config = require('../user/config-user')
+  , _ = require('lodash')
   ;
 
-function initRouter(mediator) {
+function initRouter(mediator, authResponseExclusionList) {
   var router = express.Router();
 
   router.all('/auth', function(req, res) {
@@ -15,11 +16,13 @@ function initRouter(mediator) {
       mediator.request('wfm:user:username:read', username)
       .then(function(profileData) {
         console.log('Valid credentials for user ' + username);
+        // trim the authentication response to remove specified fields
+        var authResponse = trimAuthResponse(profileData, authResponseExclusionList);
         res.json({
           status: 'ok',
           userId: username,
           sessionToken: username + '_sessiontoken',
-          authResponse: profileData
+          authResponse: authResponse
         });
       }, function() {
         console.log('Invalid credentials for user ' + username);
@@ -81,12 +84,30 @@ function initRouter(mediator) {
     });
     mediator.publish('wfm:user:delete', user);
   });
-
-
   return router;
 }
 
-module.exports = function(mediator, app) {
-  var router = initRouter(mediator);
+/**
+* Function to trim the authentication response to remove certain fields from being sent.
+* By default, the password will be removed from the response.
+* @param authResponse {object} - the untrimmed auth response
+* @param exclusionList {array} - the array of field names to remove from the authentication response
+* @return authResponse {object} - the trimmed authentication response
+*/
+function trimAuthResponse(authResponse, exclusionList) {
+  if (exclusionList === undefined || exclusionList === null) {
+    // return a default auth response if the exclusion list is null or undefined
+    return _.omit(authResponse, config.defaultAuthResponseExclusionList);
+  }
+  return _.omit(authResponse, exclusionList);
+}
+
+function init(mediator, app, authResponseExclusionList) {
+  var router = initRouter(mediator, authResponseExclusionList);
   app.use(config.apiPath, router);
+}
+
+module.exports = {
+  init: init,
+  trimAuthResponse: trimAuthResponse
 };

--- a/lib/user/config-user.js
+++ b/lib/user/config-user.js
@@ -4,5 +4,6 @@ module.exports = {
   apiHost: 'http://localhost:8080',
   apiPath: '/api/wfm/user',
   authpolicyPath: '/box/srv/1.1/admin/authpolicy',
-  policyId: process.env.WFM_AUTH_POLICY_ID || 'wfm'
+  policyId: process.env.WFM_AUTH_POLICY_ID || 'wfm',
+  defaultAuthResponseExclusionList: ['password']
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "fh-wfm-mediator": "0.0.15",
     "fh-wfm-template-build": "0.0.9",
     "grunt": "^1.0.1",
-    "grunt-eslint": "^18.0.0"
+    "grunt-eslint": "^18.0.0",
+    "grunt-mocha-test": "^0.13.2",
+    "load-grunt-tasks": "^3.5.2",
+    "mocha": "2.4.5"
   }
 }

--- a/test/fixtures/sampleUserConfig.json
+++ b/test/fixtures/sampleUserConfig.json
@@ -1,0 +1,7 @@
+{
+  "apiHost": "http://localhost:8080",
+  "apiPath": "/api/wfm/user",
+  "authpolicyPath": "/box/srv/1.1/admin/authpolicy",
+  "policyId": "wfm",
+  "authResponseExclusionList": ["password"]
+}

--- a/test/fixtures/sampleUserProfile.json
+++ b/test/fixtures/sampleUserProfile.json
@@ -1,0 +1,12 @@
+{
+  "id": "rkX1fdSH",
+  "username": "trever",
+  "name": "Trever Smith",
+  "position": "Senior Truck Driver",
+  "phone": "(265) 725 8272",
+  "email": "trever@wfm.com",
+  "notes": "Trever doesnt work during the weekends.",
+  "avatar": "https://s3.amazonaws.com/uifaces/faces/twitter/kolage/128.jpg",
+  "banner": "http://web18.streamhoster.com/pentonmedia/beefmagazine.com/TreverStockyards_38371.jpg",
+  "password": "Password"
+}


### PR DESCRIPTION
Currently the authentication response will return all fields on a user, which can include their password and other sensitive information. This has been changed to not return the password in the authentication response. Furthermore you can configure which fields should not be returned by specifying them in params.exclude, an array. Documentation was added to the readme module to cover these options and usage.