### PR TITLE
[RAINCATCH 398] Implement password authentication

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,10 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 6
   },
   "extends": "eslint:recommended",
   "rules": {
@@ -23,7 +27,8 @@
     "space-before-blocks": "error",
     "space-before-function-paren": ["error", "never"],
     "keyword-spacing": ["error"],
-    "curly": ["error", "all"]
+    "curly": ["error", "all"],
+    "no-else-return": ["error"]
   },
   "globals": {
     "angular": false,
@@ -31,4 +36,3 @@
     "localStorage": false
   }
 }
-

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,10 +1,34 @@
+'use strict';
+
 module.exports = function(grunt) {
-  'use strict';
+  require('load-grunt-tasks')(grunt);
+
   grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
     eslint: {
       src: ["lib/**/*.js"]
+    },
+
+    mochaTest: {
+      test: {
+        src: ['lib/**/*-spec.js'],
+        options: {
+          reporter: 'Spec',
+          logErrors: true,
+          timeout: 10000,
+          run: true
+        }
+      }
     }
   });
+
+  grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks("grunt-eslint");
-  grunt.registerTask('default', ['eslint']);
+  grunt.registerTask('mocha', ['mochaTest']);
+  grunt.registerTask('unit', [
+    'eslint',
+    'mocha']);
+
+  grunt.registerTask('default', ['unit']);
+
 };

--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ Base url : `/api/wfm/[group|user|membership|`
 
 Base url : `/api/wfm/user`
 
-| resource | method | returns |
-| -------- | ------ | ------- |
-| /auth | all | `{satus: 'ok', userId: username, sessionToken: sessiontoken, authResponse: profileData}` |
-| /verifysession | all | `{isValid: true}` |
-| /revokesession | all | `{}` |
+| resource | parameters | method | returns |
+| -------- | ------ | ------- | ---- |
+| /auth | all | username, password | `{satus: 'ok', userId: userId, sessionToken: sessiontoken, authResponse: profileData}` |
+| /verifysession | all | | `{isValid: true}` |
+| /revokesession | all | |  `{}` |
 
 
 

--- a/lib/router/fixtures/user.js
+++ b/lib/router/fixtures/user.js
@@ -1,0 +1,12 @@
+module.exports = {
+  id: 'rkX1fdSH',
+  username: 'trever',
+  name: 'Trever Smith',
+  position: 'Senior Truck Driver',
+  phone: '(265) 725 8272',
+  email: 'trever@wfm.com',
+  notes: 'Trever doesn\'t work during the weekends.',
+  avatar: 'https://s3.amazonaws.com/uifaces/faces/twitter/kolage/128.jpg',
+  banner: 'http://web18.streamhoster.com/pentonmedia/beefmagazine.com/TreverStockyards_38371.jpg',
+  password: 'Password'
+};

--- a/lib/router/mbaas-auth.js
+++ b/lib/router/mbaas-auth.js
@@ -1,0 +1,39 @@
+const q = require('q');
+
+
+/**
+ * Returns promise with user profile for authenticated user, or an error
+ * if user doesn't exist or is not authenticated.
+ *
+ * @param {boolean} authenticated
+ * @returns {*|promise} containing user profile for authenticated user.
+ */
+function checkAuthentication(authenticated, mediator, userIdentifier) {
+  if (authenticated) {
+    console.log('authenticated');
+    return mediator.request('wfm:user:username:read', userIdentifier);
+  }
+  var checkAuthDeferred = q.defer();
+  console.log('Invalid Credentials');
+  checkAuthDeferred.reject(new Error('Invalid Credentials'));
+  return checkAuthDeferred.promise;
+}
+
+
+/**
+ * Auth sends a request on 'wfm:user:auth' topic, raincatcher-demo-auth is subscriber
+ * of this topic and verifies passed in credentials.
+ *
+ * @param {Object} mediator object used to subscribe and publish read and auth topics
+ * @param {String} userIdentifier Unique identifier of the user.
+ * @param {String} password passed in password to be verified against user.
+ * @returns {Promise} user profile if resolved or error when invalid credentials were provided.
+ */
+exports.auth = function(mediator, userIdentifier, password) {
+  console.log('Checking credentials for user');
+  // this will return true/false result of verification or User not found error
+  return mediator.request('wfm:user:auth', {username: userIdentifier, password: password}, {uid: userIdentifier})
+    .then(function(authenticated) {
+      return checkAuthentication(authenticated, mediator, userIdentifier);
+    });
+};

--- a/lib/router/mbaas-spec.js
+++ b/lib/router/mbaas-spec.js
@@ -1,0 +1,80 @@
+const assert = require('assert');
+const mbaasRouter = require('./mbaas');
+const express = require('express');
+const supertest = require('supertest');
+const bodyParser = require('body-parser');
+const mediatorMock = require('./mocks/mediatorMock');
+const sampleUser = require('./fixtures/user');
+const sinon = require('sinon');
+
+describe('Test mbass authentication', function() {
+  var app, request;
+
+
+  beforeEach(function() {
+    mediatorMock.request.reset();
+    app = express();
+    app.use(bodyParser.json());
+    mbaasRouter(mediatorMock, app);
+    request = supertest(app);
+
+  });
+
+  it('Should log in using correct credentials', function(done) {
+    request
+      .get('/api/wfm/user/auth')
+      .send({userId: sampleUser.username, password: sampleUser.password})
+      .expect(200, function(err, res) {
+        assert.ok(!err, 'Error on valid credentials ' + err);
+        assert.ok(res, "Expected a result from the authentication request.");
+        assert.equal(res.body.status, 'ok', "Expected status ok from the successful authentication request.");
+        assert.equal(res.body.userId, sampleUser.username, "Expected user profile from the successful authentication request.");
+        assert.deepEqual(res.body.authResponse, sampleUser, "User profile in authResponse was expected to equal sampleUser.");
+        sinon.assert.calledTwice(mediatorMock.request);
+        sinon.assert.calledWith(mediatorMock.request, 'wfm:user:auth', {username: sampleUser.username, password: sampleUser.password});
+        sinon.assert.calledWith(mediatorMock.request, 'wfm:user:username:read', sampleUser.username);
+        done();
+      });
+  });
+
+  it('Should get 401 User not found when logging in with incorrect username', function(done) {
+    request
+      .get('/api/wfm/user/auth')
+      .send({userId: 'invalid_username', password: sampleUser.password})
+      .expect(401, function(err, res) {
+        assert.ok(!err, 'Error on invalid username ' + err);
+        assert.ok(res, "Expected a result from the failed authentication request.");
+        assert.equal(res.body, 'Invalid Credentials', 'Expected Invalid credentials message in response body on unsuccessful authentication request.');
+        sinon.assert.calledOnce(mediatorMock.request);
+        sinon.assert.calledWith(mediatorMock.request, 'wfm:user:auth',
+          sinon.match({
+            username: sinon.match(function(username) {
+              return username !== sampleUser.username;
+            }),
+            password: sinon.match(sampleUser.password)
+          }));
+        done();
+      });
+  });
+
+  it('Should get 401 Invalid credentials when logging in with incorrect password', function(done) {
+    request
+      .get('/api/wfm/user/auth')
+      .send({userId: sampleUser.username, password: 'invalid_password'})
+      .expect(401, function(err, res) {
+        assert.ok(!err, 'Error on invalid password ' + err);
+        assert.ok(res, "Expected a result from the authentication request.");
+        assert.equal(res.body, 'Invalid Credentials', 'Expected Invalid credentials message in response body on unsuccessful authentication request.');
+        sinon.assert.calledOnce(mediatorMock.request);
+        sinon.assert.calledWith(mediatorMock.request, 'wfm:user:auth',
+          sinon.match({
+            username: sinon.match(sampleUser.username),
+            password: sinon.match(function(password) {
+              return password !== sampleUser.password;
+            })
+          }));
+
+        done();
+      });
+  });
+});

--- a/lib/router/mbaas.js
+++ b/lib/router/mbaas.js
@@ -1,37 +1,43 @@
 'use strict';
 
-var express = require('express')
-  , config = require('../user/config-user')
-  ;
+var express = require('express');
+var config = require('../user/config-user');
+var userAuth = require('./mbaas-auth');
+
 
 function initRouter(mediator) {
   var router = express.Router();
 
   router.all('/auth', function(req, res) {
-    var params = req.body; // params.userId params.password
-    if (params && (params.userId || params.username)) {
-      var username = params.userId || params.username;
-      console.log('Checking credentials for user ' + username);
-      mediator.request('wfm:user:username:read', username)
-      .then(function(profileData) {
-        console.log('Valid credentials for user ' + username);
-        res.json({
-          status: 'ok',
-          userId: username,
-          sessionToken: username + '_sessiontoken',
-          authResponse: profileData
+    var params = req.body;
+    if (params && params.userId) {
+      var userId = params.userId;
+
+      // try to authenticate
+      userAuth.auth(mediator, userId, params.password)
+        .then(function(profileData) {
+          // on success pass relevant data into response
+          res.status = 200;
+          res.json({
+            status: 'ok',
+            userId: userId,
+            sessionToken: userId + '_sessiontoken',
+            authResponse: profileData
+          });
+        })
+        .catch(function(err) {
+          // on error pass error message into response body, assign 401 http code.
+          // 401 - invalid credentials (unauthorised)
+          res.status(401);
+          res.json(err.message ? err.message : 'Invalid Credentials');
         });
-      }, function() {
-        console.log('Invalid credentials for user ' + username);
-        res.status(400);
-        res.json({message: 'Invalid credentials'});
-      });
     } else {
       console.log('No username provided');
       res.status(400);
       res.json({message: 'Invalid credentials'});
     }
-  });
+  })
+  ;
 
   router.all('/verifysession', function(req, res) {
     res.json({

--- a/lib/router/mocks/mediatorMock.js
+++ b/lib/router/mocks/mediatorMock.js
@@ -1,0 +1,58 @@
+var sinon = require('sinon');
+require('sinon-as-promised');
+var sampleUser = require('../fixtures/user');
+
+/**
+ * This function builds sinon stub to define mediator.request() behaviour.
+ *
+ * Example usage:
+ * mediator.request('wfm:example:topic', parameter), (returns Promise)
+ * stub.withArgs('wfm:example:topic', {parameter(sinon.match)}).resolves( {return value} )
+ * stub.withArgs('wfm:example:topic', {parameter(sinon.match)}).rejects( {error})
+ *
+ * @returns {stub} mediator stub
+ */
+function getRequestStub() {
+  var stub = sinon.stub();
+
+  // valid credentials auth stub
+  stub.withArgs('wfm:user:auth', {username: sampleUser.username, password: sampleUser.password}).resolves(true);
+
+  // invalid username auth stub
+  stub.withArgs('wfm:user:auth',
+    sinon.match({
+      username: sinon.match(function(username) {
+        return username !== sampleUser.username;
+      }),
+      password: sinon.match(sampleUser.password)
+    })).rejects(new Error());
+
+
+  // invalid password auth stub
+  stub.withArgs('wfm:user:auth',
+    sinon.match({
+      username: sinon.match(sampleUser.username),
+      password: sinon.match(function(password) {
+        return password !== sampleUser.password;
+      })
+    })).rejects(new Error());
+
+  //valid username read stub
+  stub.withArgs('wfm:user:username:read', sampleUser.username)
+    .resolves(sampleUser);
+
+  // invalid username read stub
+  stub.withArgs('wfm:user:username:read',
+    sinon.match(function(username) {
+      return username !== sampleUser.username;
+    })).rejects(new Error());
+
+  return stub;
+}
+
+
+module.exports = {
+  //mediator.request()
+  request: getRequestStub()
+
+};

--- a/package.json
+++ b/package.json
@@ -21,9 +21,17 @@
     "q": "1.4.1"
   },
   "devDependencies": {
+    "body-parser": "^1.15.2",
     "fh-wfm-mediator": "0.0.15",
     "fh-wfm-template-build": "0.0.9",
     "grunt": "^1.0.1",
-    "grunt-eslint": "^18.0.0"
+    "grunt-eslint": "^18.0.0",
+    "grunt-mocha-test": "^0.13.2",
+    "grunt-shell": "1.2.1",
+    "load-grunt-tasks": "^3.5.2",
+    "mocha": "2.4.5",
+    "sinon": "^1.17.6",
+    "sinon-as-promised": "^4.0.2",
+    "supertest": "^2.0.1"
   }
 }


### PR DESCRIPTION
# Issue
Add username-password authentication

# Solution
Passwords are encrypted and verified in demo-auth module.
Raincatcher-user is publishing request on `wfm:user:auth` topic to verify provided password and username.

Accompanying work is being done in [raincatcher-demo-auth](https://github.com/feedhenry-raincatcher/raincatcher-demo-auth/pull/23)

# JIRA
https://issues.jboss.org/browse/RAINCATCH-398