### PR TITLE
RAINCATCHER-419: Added validate session middleware

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,10 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 6
   },
   "extends": "eslint:recommended",
   "rules": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
 install: npm install
 script:
   - npm test
-  - nsp check
-  - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
+  - nsp check; exit 0
+  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false
   slack:

--- a/lib/middleware/mocks/mbaasApiMock.js
+++ b/lib/middleware/mocks/mbaasApiMock.js
@@ -36,16 +36,18 @@ function cache() {
     .callsArgWith(1, undefined, null);
 
 
+
   //Save given session using the valid session token as key
   stub.withArgs(
     sinon.match({
       act: "save",
       key: "valid_sessionToken",
+      expiry: sinon.match.number,
       value: sinon.match.object
     }),
     sinon.match.func
   )
-    .callsArgWith(1, undefined);
+    .callsArgWith(1, undefined, mockSession);
 
   stub.throws("Invalid Argument");
 

--- a/lib/middleware/mocks/mbaasApiMock.js
+++ b/lib/middleware/mocks/mbaasApiMock.js
@@ -1,0 +1,59 @@
+var sinon = require('sinon');
+
+/*
+ * This function builds a sinon stub to define mbaasApi.cache() behaviour
+ */
+function cache() {
+  var stub = sinon.stub();
+  var mockSession = {
+    cuid: "some_cuid",
+    sessiontoken: "valid_sessionToken",
+    projectid:"some_project_id",
+    appid: "some_app_id",
+    appkey: "some_app_key"
+  };
+
+  //check session for a valid session token
+  stub.withArgs(
+    sinon.match({
+      act: "load",
+      key: mockSession.sessiontoken
+    }),
+    sinon.match.func
+  )
+    .callsArgWith(1, undefined, mockSession);
+
+  //check session for an invalid session token
+  stub.withArgs(
+    sinon.match({
+      act: "load",
+      key: sinon.match(function(key) {
+        return key !== mockSession.sessiontoken;
+      })
+    }),
+    sinon.match.func
+  )
+    .callsArgWith(1, undefined, null);
+
+
+  //Save given session using the valid session token as key
+  stub.withArgs(
+    sinon.match({
+      act: "save",
+      key: "valid_sessionToken",
+      value: sinon.match.object
+    }),
+    sinon.match.func
+  )
+    .callsArgWith(1, undefined);
+
+  stub.throws("Invalid Argument");
+
+  return stub;
+}
+
+module.exports = function() {
+  return {
+    cache: cache()
+  };
+};

--- a/lib/middleware/mocks/verifySessionMock.js
+++ b/lib/middleware/mocks/verifySessionMock.js
@@ -14,7 +14,7 @@ function verifySession() {
     sinon.match.object,
     sinon.match.func
   )
-    .callsArgWith(4, undefined, "OK");
+    .callsArgWith(4, undefined, mockSession);
 
   //invalid session token
   stub.withArgs(
@@ -24,7 +24,7 @@ function verifySession() {
     sinon.match.object,
     sinon.match.func
   )
-    .callsArgWith(4, undefined, 401);
+    .callsArgWith(4, undefined, null);
 
   stub.throws("Invalid Argument");
 

--- a/lib/middleware/mocks/verifySessionMock.js
+++ b/lib/middleware/mocks/verifySessionMock.js
@@ -1,0 +1,36 @@
+var sinon = require('sinon');
+
+/*
+ * This function builds a sinon stub to define the verifySession() behaviour
+ */
+function verifySession() {
+  var stub = sinon.stub();
+
+  //valid session token
+  stub.withArgs(
+    sinon.match.object,
+    sinon.match.object,
+    "some_valid_sessionToken",
+    sinon.match.object,
+    sinon.match.func
+  )
+    .callsArgWith(4, undefined, "OK");
+
+  //invalid session token
+  stub.withArgs(
+    sinon.match.object,
+    sinon.match.object,
+    "invalid_sessionToken",
+    sinon.match.object,
+    sinon.match.func
+  )
+    .callsArgWith(4, undefined, 401);
+
+  stub.throws("Invalid Argument");
+
+  return stub;
+}
+
+module.exports = function() {
+  return verifySession();
+};

--- a/lib/middleware/sessionCache.js
+++ b/lib/middleware/sessionCache.js
@@ -1,0 +1,50 @@
+/*
+ * Checks if a session exists in cache using the session token as an id and returns the session found
+ *
+ * @params {Object} mbaasApi object which allows access to cache
+ * @params {String} sessionToken string that is used as an id for the specified session in cache.
+ * @params {Function} cb function callback
+ */
+function checkSession(mbaasApi, sessionToken, cb) {
+  var options = {
+    "act": "load",
+    "key": sessionToken
+  };
+
+  mbaasApi.cache(options, function(err, session) {
+    if (err) {
+      console.log("Error getting cache value: ", err);
+      return cb(err);
+    }
+
+    return cb(undefined, session);
+  });
+}
+
+/*
+ * Saves specified session in cache
+ *
+ * @params {Object} mbaasApi object which allows access to cache
+ * @params {String} sessionToken string that is used as an id for the specified session in cache.
+ * @params {Object} session object which holds all the session details
+ * @params {Function} cb function callback
+ */
+function saveSession(mbaasApi, sessionToken, session, cb) {
+  var options = {
+    "act": "save",
+    "key": sessionToken,
+    "value": session
+  };
+
+  mbaasApi.cache(options, function(err) {
+    if (err) {
+      return cb(err);
+    }
+    return cb(undefined);
+  });
+}
+
+module.exports = {
+  checkSession: checkSession,
+  saveSession: saveSession
+};

--- a/lib/middleware/sessionCache.js
+++ b/lib/middleware/sessionCache.js
@@ -1,3 +1,5 @@
+var config = require('../user/config-user');
+
 /*
  * Checks if a session exists in cache using the session token as an id and returns the session found
  *
@@ -12,12 +14,7 @@ function checkSession(mbaasApi, sessionToken, cb) {
   };
 
   mbaasApi.cache(options, function(err, session) {
-    if (err) {
-      console.log("Error getting cache value: ", err);
-      return cb(err);
-    }
-
-    return cb(undefined, session);
+    return cb(err, session);
   });
 }
 
@@ -30,17 +27,16 @@ function checkSession(mbaasApi, sessionToken, cb) {
  * @params {Function} cb function callback
  */
 function saveSession(mbaasApi, sessionToken, session, cb) {
+
   var options = {
     "act": "save",
     "key": sessionToken,
+    "expire": config.expiry || 1800,
     "value": session
   };
 
   mbaasApi.cache(options, function(err) {
-    if (err) {
-      return cb(err);
-    }
-    return cb(undefined);
+    return cb(err, session);
   });
 }
 

--- a/lib/middleware/validateSession-spec.js
+++ b/lib/middleware/validateSession-spec.js
@@ -2,6 +2,7 @@ var sinon = require('sinon');
 var proxyquire = require('proxyquire');
 var mockMbaasApi = require('./mocks/mbaasApiMock.js');
 var mockVerifySession = require('./mocks/verifySessionMock');
+var mediator = require('fh-wfm-mediator/lib/mediator');
 
 describe('Session Validation Middleware', function() {
   var mockNext = sinon.spy();
@@ -12,15 +13,14 @@ describe('Session Validation Middleware', function() {
   mockRes.status = statusStub;
   mockRes.json = jsonStub;
 
-  var mediator,
-    mbaasApi,
+  var mbaasApi,
     validateSession;
 
   beforeEach(function(done) {
     validateSession = proxyquire('./validateSession.js', {
       './verifySession': mockVerifySession()
     });
-    mediator = {};
+
     mbaasApi = mockMbaasApi();
 
     done();

--- a/lib/middleware/validateSession-spec.js
+++ b/lib/middleware/validateSession-spec.js
@@ -1,0 +1,120 @@
+var sinon = require('sinon');
+var proxyquire = require('proxyquire');
+var mockMbaasApi = require('./mocks/mbaasApiMock.js');
+var mockVerifySession = require('./mocks/verifySessionMock');
+
+describe('Session Validation Middleware', function() {
+  var mockNext = sinon.spy();
+  var mockRes = {};
+  var statusStub = sinon.stub().returns(mockRes);
+  var jsonStub = sinon.stub().returns(mockRes);
+
+  mockRes.status = statusStub;
+  mockRes.json = jsonStub;
+
+  var mediator,
+    mbaasApi,
+    validateSession;
+
+  beforeEach(function(done) {
+    validateSession = proxyquire('./validateSession.js', {
+      './verifySession': mockVerifySession()
+    });
+    mediator = {};
+    mbaasApi = mockMbaasApi();
+
+    done();
+  });
+
+  afterEach(function(done) {
+    statusStub.reset();
+    jsonStub.reset();
+    mockNext.reset();
+
+    done();
+  });
+
+
+  it('should return 401 if no session token is available', function(done) {
+    var mockReq = {
+      fh_params: {
+        __fh: {
+          cuid: "some_cuid",
+          projectid:"some_project_id",
+          appid: "some_app_id",
+          appkey: "some_app_key"
+        }
+      }
+    };
+
+    validateSession(mediator, mbaasApi)(mockReq, mockRes, mockNext);
+    sinon.assert.calledWith(statusStub, sinon.match(401));
+    sinon.assert.calledWith(jsonStub, sinon.match(new Error("Unauthorized")));
+    sinon.assert.notCalled(mockNext);
+
+    done();
+  });
+
+  it('should proceed if session token is valid', function(done) {
+    var mockReq = {
+      fh_params: {
+        __fh: {
+          cuid: "some_cuid",
+          sessiontoken: "valid_sessionToken",
+          projectid: "some_project_id",
+          appid: "some_app_id",
+          appkey: "some_app_key"
+        }
+      }
+    };
+
+    validateSession(mediator, mbaasApi)(mockReq, mockRes, mockNext);
+    sinon.assert.notCalled(statusStub);
+    sinon.assert.notCalled(jsonStub);
+    sinon.assert.calledOnce(mockNext);
+
+    done();
+  });
+
+  it('should save a valid session if it is not in cache', function(done) {
+    var mockReq = {
+      fh_params: {
+        __fh: {
+          cuid: "some_cuid",
+          sessiontoken: "some_valid_sessionToken",
+          projectid: "some_project_id",
+          appid: "some_app_id",
+          appkey: "some_app_key"
+        }
+      }
+    };
+
+    validateSession(mediator, mbaasApi)(mockReq, mockRes, mockNext);
+    sinon.assert.notCalled(statusStub);
+    sinon.assert.notCalled(jsonStub);
+    sinon.assert.calledOnce(mockNext);
+
+    done();
+  });
+
+  it('should return a 401 if session is not valid', function(done) {
+    var mockReq = {
+      fh_params: {
+        __fh: {
+          cuid: "some_cuid",
+          sessiontoken: "invalid_sessionToken",
+          projectid: "some_project_id",
+          appid: "some_app_id",
+          appkey: "some_app_key"
+        }
+      }
+    };
+
+    validateSession(mediator, mbaasApi)(mockReq, mockRes, mockNext);
+    sinon.assert.calledOnce(statusStub);
+    sinon.assert.calledWith(jsonStub, sinon.match(new Error("Unauthorized")));
+    sinon.assert.notCalled(mockNext);
+
+    done();
+  });
+});

--- a/lib/middleware/validateSession.js
+++ b/lib/middleware/validateSession.js
@@ -33,19 +33,17 @@ module.exports = function validateSession(mediator, mbaasApi) {
         return next();
       }
 
-      verifySession(mediator, mbaasApi, sessionToken, session, function(err, response) {
+      verifySession(mediator, mbaasApi, sessionToken, session, function(err, sessionSaved) {
         if (err) {
           return res.status(500).json(err);
         }
 
-        if (response === "OK") {
-          console.log("Successfully saved session in cache");
-          return next();
-        }
-
-        if (response === 401) {
+        if (!sessionSaved) {
           return res.status(401).json(new Error("Unauthorized"));
         }
+
+        console.log("Successfully saved session in cache");
+        return next();
       });
     });
 

--- a/lib/middleware/validateSession.js
+++ b/lib/middleware/validateSession.js
@@ -1,0 +1,53 @@
+var sessionCache = require('./sessionCache');
+var verifySession = require('./verifySession');
+
+/**
+ * Middleware which validates session based on session tokens. It first checks cache if session exists,
+ * otherwise it publishes to 'wfm:user:session:validate' which verifies the session. If valid, the session
+ * is saved in cache.
+ *
+ * @param {Object} mediator object used to publish topic
+ * @param {Object} mbaasApi object used to access sessions in cache
+ * @returns {Function} validateSessionMiddleware function to validate session
+ */
+module.exports = function validateSession(mediator, mbaasApi) {
+
+  return function validateSessionMiddleware(req, res, next) {
+
+    //gets session and session token from fh_params.
+    var session = req.fh_params || {__fh: {}};
+    var sessionToken = session.__fh.sessiontoken || session.__fh.sessionToken;
+
+    if (!sessionToken) {
+      console.log("No session token available");
+      return res.status(401).json(new Error("Unauthorized"));
+    }
+
+    sessionCache.checkSession(mbaasApi, sessionToken, function(err, sessionFound) {
+      if (err) {
+        console.log("Error getting cache value: ", err);
+        return res.status(500).json(err);
+      }
+
+      if (sessionFound) {
+        return next();
+      }
+
+      verifySession(mediator, mbaasApi, sessionToken, session, function(err, response) {
+        if (err) {
+          return res.status(500).json(err);
+        }
+
+        if (response === "OK") {
+          console.log("Successfully saved session in cache");
+          return next();
+        }
+
+        if (response === 401) {
+          return res.status(401).json(new Error("Unauthorized"));
+        }
+      });
+    });
+
+  };
+};

--- a/lib/middleware/verifySession.js
+++ b/lib/middleware/verifySession.js
@@ -1,0 +1,36 @@
+var sessionCache = require('./sessionCache.js');
+
+/*
+ * Function which verifies if the session token given is valid or not. If not valid, it should return a response of
+ * 401 'Unauthorized', otherwise it should save the session in cache.
+ *
+ * @params {Object} mediator object which is used to publish topic
+ * @params {Object} mbaasApi object which used to access sessions in cache
+ * @params {String} sessionToken string used as an identifier for a specific session
+ * @params {Object} session object which contains the current session details
+ * @params {Function} cb function callback
+ */
+
+module.exports = function verifySession(mediator, mbaasApi, sessionToken, session, cb) {
+  mediator.request("wfm:user:session:validate", sessionToken)
+    .then(function(verifiedSession) {
+      if (!verifiedSession || !verifiedSession.isValid) {
+        console.log("Session is not valid");
+        return cb(undefined, 401);
+      }
+
+      sessionCache.saveSession(mbaasApi, sessionToken, session, function(err) {
+        if (err) {
+          console.log("Error saving session");
+          return cb(err);
+        }
+
+        return cb(undefined, "OK");
+
+      });
+
+    }, function(err) {
+      console.log("Error verifying session: ", err);
+      return cb(err);
+    });
+};

--- a/lib/middleware/verifySession.js
+++ b/lib/middleware/verifySession.js
@@ -11,21 +11,21 @@ var sessionCache = require('./sessionCache.js');
  * @params {Function} cb function callback
  */
 
-module.exports = function verifySession(mediator, mbaasApi, sessionToken, session, cb) {
+module.exports = function verifySession(mediator, mbaasApi, sessionToken, session, expiry, cb) {
   mediator.request("wfm:user:session:validate", sessionToken)
     .then(function(verifiedSession) {
       if (!verifiedSession || !verifiedSession.isValid) {
         console.log("Session is not valid");
-        return cb(undefined, 401);
+        return cb(undefined, null);
       }
 
-      sessionCache.saveSession(mbaasApi, sessionToken, session, function(err) {
+      sessionCache.saveSession(mbaasApi, sessionToken, session, function(err, sessionSaved) {
         if (err) {
           console.log("Error saving session");
           return cb(err);
         }
 
-        return cb(undefined, "OK");
+        return cb(undefined, sessionSaved);
 
       });
 


### PR DESCRIPTION
## Issue
Implement an express middleware to perform session validation. 

## Solution
- Made source of session ID to be configurable.
- session in mbaas-api has a get and set method for getting and saving sessions in cache. 

## JIRA Ticket 
https://issues.jboss.org/browse/RAINCATCH-419
- sub-task of ticket: https://issues.jboss.org/browse/RAINCATCH-406
