### PR TITLE
[WIP]RAINCATCH-420 Create a subscriber to session validation topic in the raincatcher-user module to call the service validate session

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,10 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 6
   },
   "extends": "eslint:recommended",
   "rules": {
@@ -23,7 +27,8 @@
     "space-before-blocks": "error",
     "space-before-function-paren": ["error", "never"],
     "keyword-spacing": ["error"],
-    "curly": ["error", "all"]
+    "curly": ["error", "all"],
+    "no-else-return": ["error"]
   },
   "globals": {
     "angular": false,
@@ -31,4 +36,3 @@
     "localStorage": false
   }
 }
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install: npm install
 script:
   - npm test
   - nsp check
-  - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
+  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false
   slack:
@@ -22,4 +22,3 @@ notifications:
       secure: >-
         lX4k0NvpjlpspUez/Co2vaSca8ZqgpeYF/onEhQP75F4LIGMz3uY9w6orLZnbU6XwkoKIVW6BxFm8vhnxGxQu3R1QKI7GkbfNUw2tfh7sxdNBN+qvgpT3lUtCPm+u2kZxLGoWKnbPh+1XooIjR+p8JUR1tAIhhZKgx9d/fwFcfxVpj9ZXQbyVQT2RLQEJF6KrWuaYpzfHMVIqoKuv5QdjW7eqzg66lMcojuwk5oYnBUx8QyWHPpzSzRLEGAzO9Zod5OGbfme78/1wyjICO/Yj4GfMZ6Wz6SORVOooRmFTEX+BVQI2NiRAAaZNc5jwTPR1rdaohzk7V9VackJAAp6XGr6ksQuiushXzT/1Qy3MFPqevsFIx6rGm+gbUsuOiRnBs72ZYZGC3xoKx2tkbcCt40ol7GPY3nuu/Aj7Ll3kpLHW7A5oCF0k30FLXT1tmDq8dU5S9vrfDNgNLLY4kcejW5q5YT+Twhl2NWVDac5swC6LP2+QgdFejrKud03N/WhQv5TOgeowS8QVG7UR73zc0ryMRphACcbqdUDbktkrjHGo//CtYqlJ6cqZLHobPF+fKj05lXRLqkrnpHoJogVY8C0hzxQVW6dHRElZi9zq7dv69gWTaRxsMsuee+AQqqbkSbLCEKCjcRQqV6Wz93dnA4a1gfO0a6Ie25M15ZDsGI=
     on_pull_requests: false
-

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,10 +1,34 @@
+'use strict';
+
 module.exports = function(grunt) {
-  'use strict';
+  require('load-grunt-tasks')(grunt);
+
   grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
     eslint: {
       src: ["lib/**/*.js"]
+    },
+
+    mochaTest: {
+      test: {
+        src: ['lib/**/*-spec.js'],
+        options: {
+          reporter: 'Spec',
+          logErrors: true,
+          timeout: 10000,
+          run: true
+        }
+      }
     }
   });
+
+  grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks("grunt-eslint");
-  grunt.registerTask('default', ['eslint']);
+  grunt.registerTask('mocha', ['mochaTest']);
+  grunt.registerTask('unit', [
+    'eslint',
+    'mocha']);
+
+  grunt.registerTask('default', ['unit']);
+
 };

--- a/lib/router/cloud.js
+++ b/lib/router/cloud.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = function(mediator, app, guid) {
+  require('../user/user-session')(mediator, app, guid);
   require('../user/user-router')(app, guid);
   require('../group/group-router')(mediator, app);
   require('../membership/membership-router')(mediator, app);

--- a/lib/user/mbaas-service-proxy.js
+++ b/lib/user/mbaas-service-proxy.js
@@ -2,11 +2,27 @@ var q = require('q')
   , $fh = require('fh-mbaas-api')
   , _ = require('lodash');
 
-var Delegate = function(guid) {
+/**
+ * Proxy for calling MBaaS Service API
+ * establishing an independent connection channel between
+ * Cloud App and MBaaS Service.
+ * @param guid name of MBaas Service
+ * @constructor
+ */
+var MbaasServiceProxy = function(guid) {
   this.guid = guid;
 };
 
-Delegate.prototype.xhr = function(_options) {
+/**
+ * MBaaS service API call
+ * @param _options we want to overwrite
+ * use default options otherwise
+ *  - guid, name of mbaas service
+ *  - path, URL of MBaaS Service API
+ *  - method, HTTP method {GET, PUT}
+ * @returns {*|promise}
+ */
+MbaasServiceProxy.prototype.xhr = function(_options) {
   var defaultOptions = {
     guid: this.guid,
     path: '/api/wfm/user',
@@ -24,17 +40,17 @@ Delegate.prototype.xhr = function(_options) {
   return deferred.promise;
 };
 
-Delegate.prototype.list = function() {
+MbaasServiceProxy.prototype.list = function() {
   return this.xhr({});
 };
 
-Delegate.prototype.read = function(id) {
+MbaasServiceProxy.prototype.read = function(id) {
   return this.xhr({
     path: '/api/wfm/user/' + id
   });
 };
 
-Delegate.prototype.update = function(user) {
+MbaasServiceProxy.prototype.update = function(user) {
   return this.xhr({
     path: '/api/wfm/user/' + user.id,
     method: 'PUT',
@@ -44,7 +60,7 @@ Delegate.prototype.update = function(user) {
   });
 };
 
-Delegate.prototype.delete = function(user) {
+MbaasServiceProxy.prototype.delete = function(user) {
   return this.xhr({
     path: '/api/wfm/user/' + user.id,
     method: 'DELETE',
@@ -54,7 +70,7 @@ Delegate.prototype.delete = function(user) {
   });
 };
 
-Delegate.prototype.create = function(user) {
+MbaasServiceProxy.prototype.create = function(user) {
   return this.xhr({
     path: '/api/wfm/user',
     method: 'POST',
@@ -64,8 +80,12 @@ Delegate.prototype.create = function(user) {
   });
 };
 
-// Delegate the
-Delegate.prototype.auth = function(params) {
+/**
+ * MBaaS service auth API call
+ * @param params to be used for
+ * @returns {*|promise}
+ */
+MbaasServiceProxy.prototype.auth = function(params) {
   var deferred = q.defer();
   $fh.service({
     'guid': this.guid,
@@ -85,22 +105,22 @@ Delegate.prototype.auth = function(params) {
   return deferred.promise;
 };
 
-Delegate.prototype.verifysession = function(sessId) {
+MbaasServiceProxy.prototype.verifysession = function(sessionToken) {
   return this.xhr({
     path: '/api/wfm/user/verifysession',
     method: 'POST',
     params: {
-      sessId: sessId
+      sessionToken: sessionToken
     }
   });
 };
 
-Delegate.prototype.revokesession = function(sessId) {
+MbaasServiceProxy.prototype.revokesession = function(sessionToken) {
   return this.xhr({
     path: '/api/wfm/user/revokesession',
     method: 'POST',
     params: {
-      sessId: sessId
+      sessionToken: sessionToken
     }
   });
 };

--- a/lib/user/stub/mbaas-service-proxy.js
+++ b/lib/user/stub/mbaas-service-proxy.js
@@ -8,7 +8,7 @@ function getMockVerifySessionStub() {
     isValid: true
   });
 
-  mockVerifySessionStub.withArgs('myinvalidvalidsessiontoken').resolves({
+  mockVerifySessionStub.withArgs('myinvalidsessiontoken').resolves({
     isValid: false
   });
 

--- a/lib/user/stub/mbaas-service-proxy.js
+++ b/lib/user/stub/mbaas-service-proxy.js
@@ -1,0 +1,31 @@
+var sinon = require('sinon');
+require('sinon-as-promised');
+
+function getMockVerifySessionStub() {
+  var mockVerifySessionStub = sinon.stub();
+
+  mockVerifySessionStub.withArgs('myvalidsessiontoken').resolves({
+    isValid: true
+  });
+
+  mockVerifySessionStub.withArgs('myinvalidvalidsessiontoken').resolves({
+    isValid: false
+  });
+
+  return mockVerifySessionStub;
+}
+
+function getMockSessionObject(verifySessionStub) {
+
+
+  function MockMbaasServiceProxy(guid) {
+    this.guid = guid;
+  }
+
+  MockMbaasServiceProxy.prototype.verifysession = verifySessionStub;
+
+  return MockMbaasServiceProxy;
+}
+
+module.exports.getMockVerifySessionStub = getMockVerifySessionStub;
+module.exports.getMockSessionObject = getMockSessionObject;

--- a/lib/user/user-delegate.js
+++ b/lib/user/user-delegate.js
@@ -1,0 +1,106 @@
+var q = require('q')
+  , $fh = require('fh-mbaas-api')
+  , _ = require('lodash');
+
+var Delegate = function(guid) {
+  this.guid = guid;
+};
+
+Delegate.prototype.xhr = function(_options) {
+  var defaultOptions = {
+    guid: this.guid,
+    path: '/api/wfm/user',
+    method: 'GET'
+  };
+  var options = _.defaults(_options, defaultOptions);
+  var deferred = q.defer();
+  $fh.service(options, function(err, data) {
+    if (err) {
+      deferred.reject(err);
+      return;
+    }
+    deferred.resolve(data);
+  });
+  return deferred.promise;
+};
+
+Delegate.prototype.list = function() {
+  return this.xhr({});
+};
+
+Delegate.prototype.read = function(id) {
+  return this.xhr({
+    path: '/api/wfm/user/' + id
+  });
+};
+
+Delegate.prototype.update = function(user) {
+  return this.xhr({
+    path: '/api/wfm/user/' + user.id,
+    method: 'PUT',
+    params: {
+      user: user
+    }
+  });
+};
+
+Delegate.prototype.delete = function(user) {
+  return this.xhr({
+    path: '/api/wfm/user/' + user.id,
+    method: 'DELETE',
+    params: {
+      user: user
+    }
+  });
+};
+
+Delegate.prototype.create = function(user) {
+  return this.xhr({
+    path: '/api/wfm/user',
+    method: 'POST',
+    params: {
+      user: user
+    }
+  });
+};
+
+// Delegate the
+Delegate.prototype.auth = function(params) {
+  var deferred = q.defer();
+  $fh.service({
+    'guid': this.guid,
+    'path': '/api/wfm/user/auth',
+    'method': 'POST',
+    'params': params
+  }, function(err, body, serviceResponse) {
+    console.log('statuscode: ', serviceResponse && serviceResponse.statusCode);
+    if (err) {
+      console.log('service call failed - err : ', err);
+      deferred.reject(err);
+    } else {
+      console.log('Got response from service - status body : ', serviceResponse.statusCode, body);
+      deferred.resolve(body);
+    }
+  });
+  return deferred.promise;
+};
+
+Delegate.prototype.verifysession = function(sessId) {
+  return this.xhr({
+    path: '/api/wfm/user/verifysession',
+    method: 'POST',
+    params: {
+      sessId: sessId
+    }
+  });
+};
+
+Delegate.prototype.revokesession = function(sessId) {
+  return this.xhr({
+    path: '/api/wfm/user/revokesession',
+    method: 'POST',
+    params: {
+      sessId: sessId
+    }
+  });
+};

--- a/lib/user/user-router.js
+++ b/lib/user/user-router.js
@@ -2,107 +2,7 @@
 
 var express = require('express')
   , config = require('./config-user')
-  , q = require('q')
-  , $fh = require('fh-mbaas-api')
-  , _ = require('lodash')
-  ;
-
-var Delegate = function(guid) {
-  this.guid = guid;
-};
-
-Delegate.prototype.xhr = function(_options) {
-  var defaultOptions = {
-    guid: this.guid,
-    path: '/api/wfm/user',
-    method: 'GET'
-  };
-  var options = _.defaults(_options, defaultOptions);
-  var deferred = q.defer();
-  $fh.service(options,function(err, data) {
-    if (err) {
-      deferred.reject(err);
-      return;
-    }
-    deferred.resolve(data);
-  });
-  return deferred.promise;
-};
-
-Delegate.prototype.list = function() {
-  return this.xhr({});
-};
-
-Delegate.prototype.read = function(id) {
-  return this.xhr({
-    path: '/api/wfm/user/' + id
-  });
-};
-
-Delegate.prototype.update = function(user) {
-  return this.xhr({
-    path: '/api/wfm/user/' + user.id,
-    method: 'PUT',
-    params: {
-      user: user
-    }
-  });
-};
-
-Delegate.prototype.delete = function(user) {
-  return this.xhr({
-    path: '/api/wfm/user/' + user.id,
-    method: 'DELETE',
-    params: {
-      user: user
-    }
-  });
-};
-
-Delegate.prototype.create = function(user) {
-  return this.xhr({
-    path: '/api/wfm/user',
-    method: 'POST',
-    params: {
-      user: user
-    }
-  });
-};
-
-// Delegate the
-Delegate.prototype.auth = function(params) {
-  var deferred = q.defer();
-  $fh.service({
-    'guid' : this.guid,
-    'path': '/api/wfm/user/auth',
-    'method': 'POST',
-    'params': params
-  }, function(err, body, serviceResponse) {
-    console.log('statuscode: ', serviceResponse && serviceResponse.statusCode);
-    if ( err ) {
-      console.log('service call failed - err : ', err);
-      deferred.reject(err);
-    } else {
-      console.log('Got response from service - status body : ', serviceResponse.statusCode, body);
-      deferred.resolve(body);
-    }
-  });
-  return deferred.promise;
-};
-
-Delegate.prototype.verifysession = function() {
-  return this.xhr({
-    path: '/api/wfm/user/verifysession',
-    method: 'POST'
-  });
-};
-
-Delegate.prototype.revokesession = function() {
-  return this.xhr({
-    path: '/api/wfm/user/revokesession',
-    method: 'POST'
-  });
-};
+  , Delegate = require('./user-delegate');
 
 function initRouter(delegate) {
   var router = express.Router();
@@ -152,41 +52,8 @@ function initRouter(delegate) {
   return router;
 }
 
-function initAuthpolicyRouter(delegate) {
-  var router = express.Router();
-
-  router.route('/auth').post(function(req, res, next) {
-    var params = req && req.body && req.body.params;
-    delegate.auth(params).then(function(data) {
-      res.json(data);
-    }, function(error) {
-      next(error);
-    });
-  });
-
-  router.route('/verifysession').post(function(req, res, next) {
-    delegate.verifysession().then(function(data) {
-      res.json(data);
-    }, function(error) {
-      next(error);
-    });
-  });
-
-  router.route('/revokesession').post(function(req, res, next) {
-    delegate.revokesession().then(function(data) {
-      res.json(data);
-    }, function(error) {
-      next(error);
-    });
-  });
-
-  return router;
-}
-
 module.exports = function(app, guid) {
   var delegate = new Delegate(guid);
   var router = initRouter(delegate);
   app.use(config.apiPath, router);
-  var authpolicyRouter = initAuthpolicyRouter(delegate);
-  app.use(config.authpolicyPath, authpolicyRouter);
 };

--- a/lib/user/user-router.js
+++ b/lib/user/user-router.js
@@ -2,13 +2,13 @@
 
 var express = require('express')
   , config = require('./config-user')
-  , Delegate = require('./user-delegate');
+  , MbaasServiceProxy = require('./mbaas-service-proxy');
 
-function initRouter(delegate) {
+function initRouter(msProxy) {
   var router = express.Router();
 
   router.route('/').get(function(req, res, next) {
-    delegate.list().then(function(users) {
+    msProxy.list().then(function(users) {
       res.json(users);
     }, function(error) {
       next(error);
@@ -18,21 +18,21 @@ function initRouter(delegate) {
     res.json(config.policyId);
   });
   router.route('/:id').get(function(req, res, next) {
-    delegate.read(req.params.id).then(function(user) {
+    msProxy.read(req.params.id).then(function(user) {
       res.json(user);
     }, function(error) {
       next(error);
     });
   });
   router.route('/:id').put(function(req, res, next) {
-    delegate.update(req.body).then(function(user) {
+    msProxy.update(req.body).then(function(user) {
       res.json(user);
     }, function(error) {
       next(error);
     });
   });
   router.route('/').post(function(req, res, next) {
-    delegate.create(req.body).then(function(user) {
+    msProxy.create(req.body).then(function(user) {
       res.json(user);
     }, function(error) {
       next(error);
@@ -40,7 +40,7 @@ function initRouter(delegate) {
   });
   router.route('/:id').delete(function(req, res, next) {
     console.log('delete');
-    delegate.delete(req.body).then(function(user) {
+    msProxy.delete(req.body).then(function(user) {
       console.log('delete success');
       res.json(user);
     }, function(error) {
@@ -53,7 +53,7 @@ function initRouter(delegate) {
 }
 
 module.exports = function(app, guid) {
-  var delegate = new Delegate(guid);
-  var router = initRouter(delegate);
+  var msProxy = new MbaasServiceProxy(guid);
+  var router = initRouter(msProxy);
   app.use(config.apiPath, router);
 };

--- a/lib/user/user-router.js
+++ b/lib/user/user-router.js
@@ -52,6 +52,11 @@ function initRouter(msProxy) {
   return router;
 }
 
+/**
+ * Route User requests to config.apiPath endpoint
+ * @param app cloud application
+ * @param guid
+ */
 module.exports = function(app, guid) {
   var msProxy = new MbaasServiceProxy(guid);
   var router = initRouter(msProxy);

--- a/lib/user/user-session-spec.js
+++ b/lib/user/user-session-spec.js
@@ -1,0 +1,42 @@
+var mockMbaasServiceProxy = require('./stub/mbaas-service-proxy');
+var mediator = require('fh-wfm-mediator/lib/mediator');
+var express = require('express');
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+var assert = require('assert');
+
+var sessionManager;
+
+describe("Mbaas Service Proxy", function() {
+
+  beforeEach(function() {
+    var verifySessionStub = mockMbaasServiceProxy.getMockVerifySessionStub();
+
+    sessionManager = proxyquire('./user-session', {
+      './mbaas-service-proxy': mockMbaasServiceProxy.getMockSessionObject(verifySessionStub)
+    });
+
+    sessionManager(mediator, express(), 'service-name-guid');
+  });
+
+  it("Testing valid session token", function(done) {
+
+    mediator.request('wfm:user:session:validate', 'myvalidsessiontoken', function(err, validationResponse) {
+      sinon.assert.calledOnce(mockMbaasServiceProxy.getMockVerifySessionStub());
+      assert.ok(!err, 'Error on myvalidsessiontoken' + err);
+      assert(validationResponse.isValid === true);
+      done();
+    });
+  });
+
+  it("Testing invalid session token", function(done) {
+
+    sessionManager(mediator, express(), 'service-name-guid');
+    mediator.request('wfm:user:session:validate', 'myinvalidvalidsessiontoken', function(err, validationResponse) {
+      sinon.assert.calledOnce(mockMbaasServiceProxy.getMockVerifySessionStub());
+      assert.ok(!err, 'Error on myinvalidvalidsessiontoken' + err);
+      console.log('>>>>>>' + validationResponse.isValid);
+      done();
+    });
+  });
+});

--- a/lib/user/user-session-spec.js
+++ b/lib/user/user-session-spec.js
@@ -8,21 +8,21 @@ var assert = require('assert');
 var sessionManager;
 
 describe("Mbaas Service Proxy", function() {
+  var verifySessionStub;
 
   beforeEach(function() {
-    var verifySessionStub = mockMbaasServiceProxy.getMockVerifySessionStub();
 
+    verifySessionStub = mockMbaasServiceProxy.getMockVerifySessionStub();
     sessionManager = proxyquire('./user-session', {
       './mbaas-service-proxy': mockMbaasServiceProxy.getMockSessionObject(verifySessionStub)
     });
-
-    sessionManager(mediator, express(), 'service-name-guid');
+    sessionManager(mediator, express(), 'service-name-guid1');
   });
 
   it("Testing valid session token", function(done) {
 
     mediator.request('wfm:user:session:validate', 'myvalidsessiontoken', function(err, validationResponse) {
-      sinon.assert.calledOnce(mockMbaasServiceProxy.getMockVerifySessionStub());
+      sinon.assert.calledOnce(verifySessionStub);
       assert.ok(!err, 'Error on myvalidsessiontoken' + err);
       assert(validationResponse.isValid === true);
       done();
@@ -31,11 +31,11 @@ describe("Mbaas Service Proxy", function() {
 
   it("Testing invalid session token", function(done) {
 
-    sessionManager(mediator, express(), 'service-name-guid');
-    mediator.request('wfm:user:session:validate', 'myinvalidvalidsessiontoken', function(err, validationResponse) {
-      sinon.assert.calledOnce(mockMbaasServiceProxy.getMockVerifySessionStub());
+    sessionManager(mediator, express(), 'service-name-guid2');
+    mediator.request('wfm:user:session:validate', 'myinvalidsessiontoken', function(err, validationResponse) {
+      sinon.assert.calledOnce(verifySessionStub);
       assert.ok(!err, 'Error on myinvalidvalidsessiontoken' + err);
-      console.log('>>>>>>' + validationResponse.isValid);
+      assert(validationResponse.isValid === true);
       done();
     });
   });

--- a/lib/user/user-session-spec.js
+++ b/lib/user/user-session-spec.js
@@ -7,11 +7,10 @@ var assert = require('assert');
 
 var sessionManager;
 
-describe("Mbaas Service Proxy", function() {
+describe("User Sessions", function() {
   var verifySessionStub;
 
   beforeEach(function() {
-
     verifySessionStub = mockMbaasServiceProxy.getMockVerifySessionStub();
     sessionManager = proxyquire('./user-session', {
       './mbaas-service-proxy': mockMbaasServiceProxy.getMockSessionObject(verifySessionStub)
@@ -20,23 +19,25 @@ describe("Mbaas Service Proxy", function() {
   });
 
   it("Testing valid session token", function(done) {
-
-    mediator.request('wfm:user:session:validate', 'myvalidsessiontoken', function(err, validationResponse) {
+    mediator.request('wfm:user:session:validate', 'myvalidsessiontoken').then(function(validationResponse) {
       sinon.assert.calledOnce(verifySessionStub);
-      assert.ok(!err, 'Error on myvalidsessiontoken' + err);
       assert(validationResponse.isValid === true);
+      done();
+    }).catch(function(err) {
+      assert.ok(!err, 'Error on myvalidsessiontoken' + err);
       done();
     });
   });
 
   it("Testing invalid session token", function(done) {
-
-    sessionManager(mediator, express(), 'service-name-guid2');
-    mediator.request('wfm:user:session:validate', 'myinvalidsessiontoken', function(err, validationResponse) {
+    mediator.request('wfm:user:session:validate', 'myinvalidsessiontoken').then(function(validationResponse) {
       sinon.assert.calledOnce(verifySessionStub);
-      assert.ok(!err, 'Error on myinvalidvalidsessiontoken' + err);
-      assert(validationResponse.isValid === true);
+      assert(validationResponse.isValid === false);
       done();
-    });
+    })
+      .catch(function(err) {
+        assert.ok(!err, 'Error on myinvalidvalidsessiontoken' + err);
+        done();
+      });
   });
 });

--- a/lib/user/user-session.js
+++ b/lib/user/user-session.js
@@ -1,13 +1,13 @@
 var express = require('express')
   , config = require('./config-user')
-  , Delegate = require('./user-delegate');
+  , MbaasServiceProxy = require('./mbaas-service-proxy');
 
-function initRouter(delegate) {
+function initRouter(msProxy) {
   var router = express.Router();
 
   router.route('/auth').post(function(req, res, next) {
     var params = req && req.body && req.body.params;
-    delegate.auth(params).then(function(data) {
+    msProxy.auth(params).then(function(data) {
       res.json(data);
     }, function(error) {
       next(error);
@@ -15,7 +15,9 @@ function initRouter(delegate) {
   });
 
   router.route('/verifysession').post(function(req, res, next) {
-    delegate.verifysession().then(function(data) {
+    var fhParams = req.fh_params || {__fh: {}};
+    var sessionToken = fhParams.__fh.sessionToken || fhParams.__fh.sessiontoken;
+    msProxy.verifysession(sessionToken).then(function(data) {
       res.json(data);
     }, function(error) {
       next(error);
@@ -23,7 +25,9 @@ function initRouter(delegate) {
   });
 
   router.route('/revokesession').post(function(req, res, next) {
-    delegate.revokesession().then(function(data) {
+    var fhParams = req.fh_params || {__fh: {}};
+    var sessionToken = fhParams.__fh.sessionToken || fhParams.__fh.sessiontoken;
+    msProxy.revokesession(sessionToken).then(function(data) {
       res.json(data);
     }, function(error) {
       next(error);
@@ -37,17 +41,19 @@ module.exports = function(mediator, app, guid) {
   var self = this;
   self.mediator - mediator;
 
-  var delegate = new Delegate(guid);
-  var router = initRouter(delegate);
+  var msProxy = new MbaasServiceProxy(guid);
+  var router = initRouter(msProxy);
   app.use(config.authpolicyPath, router);
 
-  mediator.subscribe('wfm:session:validate', function(sessId) {
-    return delegate.verifysession(sessId)
-      .then(function() {
-        self.mediator.publish('done:' + 'wfm:session:validate');
+  // subscribe for session validation topic
+  mediator.subscribe('wfm:user:session:validate', function(sessionToken) {
+    return msProxy.verifysession(sessionToken)
+      .then(function(validationResponse) {
+        // needs to publish the validation response for the consumer
+        self.mediator.publish('done:' + 'wfm:user:session:validate', validationResponse);
       })
       .catch(function(err) {
-        self.mediator.publish('error:' + 'wfm:session:validate', err);
+        self.mediator.publish('error:' + 'wfm:user:session:validate', err);
       });
   });
 };

--- a/lib/user/user-session.js
+++ b/lib/user/user-session.js
@@ -1,0 +1,44 @@
+var express = require('express')
+  , config = require('./config-user')
+  , Delegate = require('./user-delegate');
+
+function initRouter(delegate) {
+  var router = express.Router();
+
+  router.route('/auth').post(function(req, res, next) {
+    var params = req && req.body && req.body.params;
+    delegate.auth(params).then(function(data) {
+      res.json(data);
+    }, function(error) {
+      next(error);
+    });
+  });
+
+  router.route('/verifysession').post(function(req, res, next) {
+    delegate.verifysession().then(function(data) {
+      res.json(data);
+    }, function(error) {
+      next(error);
+    });
+  });
+
+  router.route('/revokesession').post(function(req, res, next) {
+    delegate.revokesession().then(function(data) {
+      res.json(data);
+    }, function(error) {
+      next(error);
+    });
+  });
+
+  return router;
+}
+
+module.exports = function(mediator, app, guid) {
+  var delegate = new Delegate(guid);
+  var router = initRouter(delegate);
+  app.use(config.authpolicyPath, router);
+
+  mediator.subscribe('wfm:session:validate', function(sessId) {
+    delegate.verifysession(sessId);
+  });
+};

--- a/lib/user/user-session.js
+++ b/lib/user/user-session.js
@@ -37,9 +37,16 @@ function initRouter(msProxy) {
   return router;
 }
 
+/**
+ * Subscribe for user session validation
+ * Route Auth requests to config.authpolicyPath endpoint
+ * @param mediator subscribe for all validation messages
+ * @param app cloud application
+ * @param guid name of MBaas Service
+ */
 module.exports = function(mediator, app, guid) {
   var self = this;
-  self.mediator - mediator;
+  self.mediator = mediator;
 
   var msProxy = new MbaasServiceProxy(guid);
   var router = initRouter(msProxy);

--- a/lib/user/user-session.js
+++ b/lib/user/user-session.js
@@ -34,11 +34,20 @@ function initRouter(delegate) {
 }
 
 module.exports = function(mediator, app, guid) {
+  var self = this;
+  self.mediator - mediator;
+
   var delegate = new Delegate(guid);
   var router = initRouter(delegate);
   app.use(config.authpolicyPath, router);
 
   mediator.subscribe('wfm:session:validate', function(sessId) {
-    delegate.verifysession(sessId);
+    return delegate.verifysession(sessId)
+      .then(function() {
+        self.mediator.publish('done:' + 'wfm:session:validate');
+      })
+      .catch(function(err) {
+        self.mediator.publish('error:' + 'wfm:session:validate', err);
+      });
   });
 };

--- a/lib/user/user-session.js
+++ b/lib/user/user-session.js
@@ -54,13 +54,14 @@ module.exports = function(mediator, app, guid) {
 
   // subscribe for session validation topic
   self.mediator.subscribe('wfm:user:session:validate', function(sessionToken) {
+
     return msProxy.verifysession(sessionToken)
       .then(function(validationResponse) {
-        // needs to publish the validation response for the consumer
-        self.mediator.publish('done:' + 'wfm:user:session:validate', validationResponse);
+        // needs to publish the validation response topic
+        self.mediator.publish('done:' + 'wfm:user:session:validate:' + sessionToken, validationResponse);
       })
       .catch(function(err) {
-        self.mediator.publish('error:' + 'wfm:user:session:validate', err);
+        self.mediator.publish('error:' + 'wfm:user:session:validate' + sessionToken, err);
       });
   });
 };

--- a/lib/user/user-session.js
+++ b/lib/user/user-session.js
@@ -53,7 +53,7 @@ module.exports = function(mediator, app, guid) {
   app.use(config.authpolicyPath, router);
 
   // subscribe for session validation topic
-  mediator.subscribe('wfm:user:session:validate', function(sessionToken) {
+  self.mediator.subscribe('wfm:user:session:validate', function(sessionToken) {
     return msProxy.verifysession(sessionToken)
       .then(function(validationResponse) {
         // needs to publish the validation response for the consumer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "A user module for WFM",
   "main": "lib/angular/user-ng.js",
   "scripts": {
@@ -18,12 +18,23 @@
     "express": "4.14.0",
     "fh-mbaas-api": "5.14.2",
     "lodash": "4.7.0",
-    "q": "1.4.1"
+    "q": "1.4.1",
+    "semver": "^5.3.0",
+    "shortid": "^2.2.6"
   },
   "devDependencies": {
+    "body-parser": "^1.15.2",
     "fh-wfm-mediator": "0.0.15",
     "fh-wfm-template-build": "0.0.9",
     "grunt": "^1.0.1",
-    "grunt-eslint": "^18.0.0"
+    "grunt-eslint": "^18.0.0",
+    "grunt-mocha-test": "^0.13.2",
+    "grunt-shell": "1.2.1",
+    "load-grunt-tasks": "^3.5.2",
+    "mocha": "2.4.5",
+    "proxyquire": "^1.7.10",
+    "sinon": "^1.17.6",
+    "sinon-as-promised": "^4.0.2",
+    "supertest": "^2.0.1"
   }
 }


### PR DESCRIPTION
**Motivation**
    Add a new function to the raincatcher-user lib/user folder. It should subscribe to the session validation topic and call the service authentication endpoint. Refactor the delegate function to be called from the new session validation mediator topic. This should be added to the setup function for the raincatcher-user cloud APIs. 

module.exports = function(mediator, app, guid) {
  require('../user/user-session')(mediator, app, guid);
  require('../user/user-router')(app, guid);
  require('../group/group-router')(mediator, app);
  require('../membership/membership-router')(mediator, app);
};
