### PR TITLE
Raincatch-403/399

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 install: npm install
 script:
   - npm test
-  - nsp check
+  - nsp check; exit 0
   - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false
@@ -22,4 +22,3 @@ notifications:
       secure: >-
         lX4k0NvpjlpspUez/Co2vaSca8ZqgpeYF/onEhQP75F4LIGMz3uY9w6orLZnbU6XwkoKIVW6BxFm8vhnxGxQu3R1QKI7GkbfNUw2tfh7sxdNBN+qvgpT3lUtCPm+u2kZxLGoWKnbPh+1XooIjR+p8JUR1tAIhhZKgx9d/fwFcfxVpj9ZXQbyVQT2RLQEJF6KrWuaYpzfHMVIqoKuv5QdjW7eqzg66lMcojuwk5oYnBUx8QyWHPpzSzRLEGAzO9Zod5OGbfme78/1wyjICO/Yj4GfMZ6Wz6SORVOooRmFTEX+BVQI2NiRAAaZNc5jwTPR1rdaohzk7V9VackJAAp6XGr6ksQuiushXzT/1Qy3MFPqevsFIx6rGm+gbUsuOiRnBs72ZYZGC3xoKx2tkbcCt40ol7GPY3nuu/Aj7Ll3kpLHW7A5oCF0k30FLXT1tmDq8dU5S9vrfDNgNLLY4kcejW5q5YT+Twhl2NWVDac5swC6LP2+QgdFejrKud03N/WhQv5TOgeowS8QVG7UR73zc0ryMRphACcbqdUDbktkrjHGo//CtYqlJ6cqZLHobPF+fKj05lXRLqkrnpHoJogVY8C0hzxQVW6dHRElZi9zq7dv69gWTaRxsMsuee+AQqqbkSbLCEKCjcRQqV6Wz93dnA4a1gfO0a6Ie25M15ZDsGI=
     on_pull_requests: false
-

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,9 +25,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks("grunt-eslint");
   grunt.registerTask('mocha', ['mochaTest']);
-  grunt.registerTask('unit', [
-    'eslint',
-    'mocha']);
+  grunt.registerTask('unit', ['eslint', 'mocha']);
 
   grunt.registerTask('default', ['unit']);
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ var authServiceGuid = process.env.WFM_AUTH_GUID;
 ...
 
 // setup the wfm user router
-require('fh-wfm-user/lib/router/mbaas')(mediator, app);
+require('fh-wfm-user/lib/router/mbaas')(mediator, app, authResponseExclusionList);
 ```
+
+Note: Setting the `authResponseExclusionList` array as `['password', 'banner']` will prevent these fields from appearing in the authentication response. By default, the `password` field is removed from the response. To allow all fields to be sent, set `authResponseExclusionList` as an empty array.
 
 For a more complete example check [here](https://github.com/feedhenry-raincatcher/raincatcher-demo-auth)
 
@@ -124,11 +126,11 @@ Base url : `/api/wfm/[group|user|membership|`
 
 Base url : `/api/wfm/user`
 
-| resource | parameters | method | returns |
+| resource | parameters | method | returns | description |
 | -------- | ------ | ------- | ---- |
-| /auth | all | username, password | `{satus: 'ok', userId: userId, sessionToken: sessiontoken, authResponse: profileData}` |
-| /verifysession | all | | `{isValid: true}` |
-| /revokesession | all | |  `{}` |
+| /auth | all | `{status: 'ok', userId: username, sessionToken: sessiontoken, authResponse: authResponse}` | `sessionToken` : identifier for a specific user for the duration of that user's visit. <br>  `authResponse` : authentication response containing the authenticated users details. |
+| /verifysession | all | `{isValid: true}` | |
+| /revokesession | all | `{}` |  | |
 
 
 

--- a/lib/config/sessionStorageProviders.js
+++ b/lib/config/sessionStorageProviders.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  providers: ['mongo']
+};

--- a/lib/router/mbaas-auth.js
+++ b/lib/router/mbaas-auth.js
@@ -1,23 +1,4 @@
-var q = require('q');
-
-
-/**
- * Returns promise with user profile for authenticated user, or an error
- * if user doesn't exist or is not authenticated.
- *
- * @param {boolean} authenticated
- * @returns {*|promise} containing user profile for authenticated user.
- */
-function checkAuthentication(authenticated, mediator, userIdentifier) {
-  if (authenticated) {
-    console.log('authenticated');
-    return mediator.request('wfm:user:username:read', userIdentifier);
-  }
-  var checkAuthDeferred = q.defer();
-  console.log('Invalid Credentials');
-  checkAuthDeferred.reject(new Error('Invalid Credentials'));
-  return checkAuthDeferred.promise;
-}
+const q = require('q');
 
 /**
  * Auth sends a request on 'wfm:user:auth' topic, raincatcher-demo-auth is subscriber
@@ -26,13 +7,30 @@ function checkAuthentication(authenticated, mediator, userIdentifier) {
  * @param {Object} mediator object used to subscribe and publish read and auth topics
  * @param {String} userIdentifier Unique identifier of the user.
  * @param {String} password passed in password to be verified against user.
- * @returns {Promise} user profile if resolved or error when invalid credentials were provided.
+ *
  */
 exports.auth = function(mediator, userIdentifier, password) {
+
+  /**
+   * Returns promise with user profile for authenticated user, or an error
+   * if user doesn't exist or is not authenticated.
+   *
+   * @param {boolean} authenticated
+   * @returns {*|promise} containing user profile for authenticated user.
+   */
+  function checkAuthentication(authenticated) {
+    if (authenticated) {
+      console.log('authenticated');
+      return mediator.request('wfm:user:username:read', userIdentifier);
+    }
+    var checkAuthDeferred = q.defer();
+    console.log('Invalid Credentials');
+    checkAuthDeferred.reject(new Error('Invalid Credentials'));
+    return checkAuthDeferred.promise;
+  }
+
   console.log('Checking credentials for user');
   // this will return true/false result of verification or User not found error
   return mediator.request('wfm:user:auth', {username: userIdentifier, password: password}, {uid: userIdentifier})
-    .then(function(authenticated) {
-      return checkAuthentication(authenticated, mediator, userIdentifier);
-    });
+    .then(checkAuthentication);
 };

--- a/lib/router/mbaas-session-middleware.js
+++ b/lib/router/mbaas-session-middleware.js
@@ -1,0 +1,60 @@
+const session = require('express-session');
+const MongoStore = require('connect-mongo')(session);
+var _ = require('lodash');
+var sessionProviders = require('../config/sessionStorageProviders').providers;
+
+
+/**
+* Function to setup express-session and connect-mongo with the configuration sent from the raincatcher-demo-auth application.
+* Default configuration options are also provided.
+* @param sessionConfig {object} - the configuration for express-session and connect-mongo
+* @callback cb - err, session config for connect-mongo
+*/
+function initSession(sessionConfig, cb) {
+  if (!(_.isObject(sessionConfig))) {
+    return cb("Error: Session Config is not a valid Object", null);
+  }
+
+  if (sessionConfig && !(sessionProviders.indexOf(sessionConfig.store) > -1)) {
+    return cb("Error: Session Storage Provider is not supported.", null);
+  }
+
+  console.log("Using mongo session store");
+
+    // don't allow store to be overwritten since it needs to be defined here
+  var expressSessionConfig = _.defaults(sessionConfig, {
+    store: MongoStore,
+    config: {
+      secret: process.env.FH_COOKIE_SECRET || 'raincatcher',
+      host: '127.0.0.1',
+      port: '27017',
+      db: 'session',
+      url: 'mongodb://localhost:27017/raincatcher-demo-auth-session-store',
+      resave: false,
+      saveUninitialized: true,
+      cookie: {
+        secure: process.env.NODE_ENV !== 'development',
+        httpOnly: true,
+        path: '/'
+      }
+    }
+  });
+
+  var config = {session: session, options: expressSessionConfig, store: new MongoStore(expressSessionConfig.config)};
+  return cb(null, config);
+}
+
+
+function isSessionValid(req, res, next) {
+  if (req.sessionID) {
+    // check if session is valid
+    return next();
+  }
+  // session not valid
+  res.redirect('/');
+}
+
+module.exports = {
+  isSessionValid: isSessionValid,
+  initSession: initSession
+};

--- a/lib/router/mbaas-spec.js
+++ b/lib/router/mbaas-spec.js
@@ -1,4 +1,9 @@
-var assert = require('assert');
+var _ = require('lodash');
+const assert = require('assert');
+const authHandler = require('./mbaas');
+const sampleUserConfig = require('../../test/fixtures/sampleUserConfig.json');
+const sampleProfileData = require('../../test/fixtures/sampleUserProfile.json');
+const sampleProfileDataLength  = Object.keys(sampleProfileData).length;
 var mbaasRouter = require('./mbaas');
 var express = require('express');
 var supertest = require('supertest');
@@ -7,15 +12,20 @@ var mediatorMock = require('./mocks/mediatorMock');
 var sampleUser = require('./fixtures/user');
 var sinon = require('sinon');
 
+var sampleExclusionList1 = ['banner'];
+var sampleExclusionList2 = ['banner', 'avatar'];
+var sampleExclusionList3 = [];
+var sampleExclusionList4 = undefined;
+var sampleExclusionList5 = null;
+
 describe('Test mbass authentication', function() {
   var app, request;
-
 
   beforeEach(function() {
     mediatorMock.request.reset();
     app = express();
     app.use(bodyParser.json());
-    mbaasRouter(mediatorMock, app);
+    mbaasRouter.init(mediatorMock, app);
     request = supertest(app);
 
   });
@@ -29,7 +39,6 @@ describe('Test mbass authentication', function() {
         assert.ok(res, "Expected a result from the authentication request.");
         assert.equal(res.body.status, 'ok', "Expected status ok from the successful authentication request.");
         assert.equal(res.body.userId, sampleUser.username, "Expected user profile from the successful authentication request.");
-        assert.deepEqual(res.body.authResponse, sampleUser, "User profile in authResponse was expected to equal sampleUser.");
         sinon.assert.calledTwice(mediatorMock.request);
         sinon.assert.calledWith(mediatorMock.request, 'wfm:user:auth', {username: sampleUser.username, password: sampleUser.password});
         sinon.assert.calledWith(mediatorMock.request, 'wfm:user:username:read', sampleUser.username);
@@ -76,5 +85,51 @@ describe('Test mbass authentication', function() {
 
         done();
       });
+  });
+});
+
+describe('#testAuthResponseData', function() {
+  it('it should not remove any fields when an empty exclusion list is specified', function(done) {
+    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList3);
+    assert(Object.keys(authResponse).length === sampleProfileDataLength, "Expect that specifying an empty exclusion list returns all the User fields in the response.");
+    done();
+  });
+  it('it should remove the password field by default', function(done) {
+    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleUserConfig.authResponseExclusionList);
+    assert(authResponse.password === undefined, "Check that the Password field has been removed from the Response.");
+    assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that the auth response has a different length to the user profile data.");
+    done();
+  });
+  it('it should remove a single field when specified', function(done) {
+    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList1);
+    assert(authResponse.banner === undefined, "Check that the Banner field has been removed from the Response.");
+    assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that the auth response has a different length to the user profile data.");
+    done();
+  });
+  it('it should remove a single field when specified and also not remove the password', function(done) {
+    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList1);
+    assert(authResponse.banner === undefined, "Check that the Banner field has been removed from the Response.");
+    assert(authResponse.password !== undefined, "Check that the Password field has Not been removed from the Response.");
+    assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that the auth response has a different length to the user profile data.");
+    done();
+  });
+  it('it should remove a number of fields when specified', function(done) {
+    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList2);
+    assert(authResponse.banner === undefined, "Check that the Banner field has been removed from the Response.");
+    assert(authResponse.avatar === undefined, "Check that the Avatar field has been removed from the Response.");
+    assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that the auth response has a different length to the user profile data.");
+    done();
+  });
+  it('it should remove the password field by default when the exclusion list is undefined', function(done) {
+    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList4);
+    assert(authResponse.password === undefined, "Check that the Password field has been removed from the Response.");
+    assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that specifying an undefined exclusion list will result in the default exclusion list being used");
+    done();
+  });
+  it('it should remove the password field by default when the exclusion list is null', function(done) {
+    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList5);
+    assert(authResponse.password === undefined, "Check that the Password field has been removed from the Response.");
+    assert(Object.keys(authResponse).length !== sampleProfileDataLength, "Expect that specifying a null exclusion list will result in the default exclusion list being used.");
+    done();
   });
 });

--- a/lib/router/mbaas.js
+++ b/lib/router/mbaas.js
@@ -3,8 +3,10 @@
 var express = require('express');
 var config = require('../user/config-user');
 var userAuth = require('./mbaas-auth');
+var sessionMiddleware = require('./mbaas-session-middleware');
+var _ = require('lodash');
 
-function initRouter(mediator) {
+function initRouter(mediator, authResponseExclusionList) {
   var router = express.Router();
 
   router.all('/auth', function(req, res) {
@@ -15,13 +17,16 @@ function initRouter(mediator) {
       // try to authenticate
       userAuth.auth(mediator, userId, params.password)
         .then(function(profileData) {
+          // trim the authentication response to remove specified fields
+          var authResponse = trimAuthResponse(profileData, authResponseExclusionList);
           // on success pass relevant data into response
+
           res.status = 200;
           res.json({
             status: 'ok',
             userId: userId,
-            sessionToken: userId + '_sessiontoken',
-            authResponse: profileData
+            sessionToken: req.sessionID,
+            authResponse: authResponse
           });
         })
         .catch(function(err) {
@@ -86,12 +91,41 @@ function initRouter(mediator) {
     });
     mediator.publish('wfm:user:delete', user);
   });
-
-
   return router;
 }
 
-module.exports = function(mediator, app) {
-  var router = initRouter(mediator);
+/**
+* Function to trim the authentication response to remove certain fields from being sent.
+* By default, the password will be removed from the response.
+* @param authResponse {object} - the untrimmed auth response
+* @param exclusionList {array} - the array of field names to remove from the authentication response
+* @return authResponse {object} - the trimmed authentication response
+*/
+function trimAuthResponse(authResponse, exclusionList) {
+  if (exclusionList === undefined || exclusionList === null) {
+    // return a default auth response if the exclusion list is null or undefined
+    return _.omit(authResponse, config.defaultAuthResponseExclusionList);
+  }
+  return _.omit(authResponse, exclusionList);
+}
+
+function init(mediator, app, authResponseExclusionList, sessionOptions) {
+  var router = initRouter(mediator, authResponseExclusionList);
+  sessionMiddleware.initSession(sessionOptions, function(err, result) {
+    if (err) {
+      return err;
+    }
+    app.use(result.session({
+      secret: result.options.config.secret,
+      store: result.store,
+      resave: result.options.config.esave,
+      saveUninitialized: result.options.config.saveUninitialized
+    }));
+  });
   app.use(config.apiPath, router);
+}
+
+module.exports = {
+  init: init,
+  trimAuthResponse: trimAuthResponse
 };

--- a/lib/user/config-user.js
+++ b/lib/user/config-user.js
@@ -4,5 +4,6 @@ module.exports = {
   apiHost: 'http://localhost:8080',
   apiPath: '/api/wfm/user',
   authpolicyPath: '/box/srv/1.1/admin/authpolicy',
-  policyId: process.env.WFM_AUTH_POLICY_ID || 'wfm'
+  policyId: process.env.WFM_AUTH_POLICY_ID || 'wfm',
+  defaultAuthResponseExclusionList: ['password']
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Brian Leathem",
   "license": "MIT",
   "dependencies": {
+    "connect-mongo": "^1.3.2",
     "express": "4.14.0",
     "fh-mbaas-api": "5.14.2",
     "lodash": "4.7.0",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "body-parser": "^1.15.2",
+    "cookie-parser": "^1.4.3",
     "fh-wfm-template-build": "0.0.9",
     "grunt": "^1.0.1",
     "grunt-eslint": "^18.0.0",

--- a/test/fixtures/sampleUserConfig.json
+++ b/test/fixtures/sampleUserConfig.json
@@ -1,0 +1,7 @@
+{
+  "apiHost": "http://localhost:8080",
+  "apiPath": "/api/wfm/user",
+  "authpolicyPath": "/box/srv/1.1/admin/authpolicy",
+  "policyId": "wfm",
+  "authResponseExclusionList": ["password"]
+}

--- a/test/fixtures/sampleUserProfile.json
+++ b/test/fixtures/sampleUserProfile.json
@@ -1,0 +1,12 @@
+{
+  "id": "rkX1fdSH",
+  "username": "trever",
+  "name": "Trever Smith",
+  "position": "Senior Truck Driver",
+  "phone": "(265) 725 8272",
+  "email": "trever@wfm.com",
+  "notes": "Trever doesnt work during the weekends.",
+  "avatar": "https://s3.amazonaws.com/uifaces/faces/twitter/kolage/128.jpg",
+  "banner": "http://web18.streamhoster.com/pentonmedia/beefmagazine.com/TreverStockyards_38371.jpg",
+  "password": "Password"
+}


### PR DESCRIPTION
**Motivation**

Added functionality to trim the response. 
Added session storage in mongo.
The session token is stored in `fh_session_token.sessionToken` (localstorage) after authenticating.

**Still required**: 
- Implement the `/verifySession` endpoint. This should check whether the incoming session key is valid (check against the ones in mongo), if so return true, otherwise false etc.
- Update the readme to include the new session information.