### PR TITLE
[RAINCATCH-450] Use simple-store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,9 @@ node_js:
 services:
   - docker
 sudo: false
-before_install:
-  - npm install -g npm@2.13.5
-  - npm install -g nsp
-install: npm install
 script:
   - npm test
-  - nsp check; exit 0
+  - npm run vuln; exit 0
   - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - '4.4'
 services:
   - docker
+  - redis-server
 sudo: false
 script:
   - npm test

--- a/lib/user/store-spec.js
+++ b/lib/user/store-spec.js
@@ -30,68 +30,76 @@ function hrtimeDiff(start, end) {
 
 describe('store', function() {
   beforeEach(function() {
-    store = new Store('user', fixtures);
+    store = new Store('user');
+    return store.init(fixtures);
+  });
+  afterEach(function() {
+    return store.deleteAll();
   });
   describe('#list', function() {
-    it('should return all users', function(done) {
-      store.list().then(function(res) {
+    it('should return all users', function() {
+      return store.list().then(function(res) {
         assert.equal(res.length, fixtures.length);
-      }).then(done).catch(done);
+      });
     });
   });
   describe('#read', function() {
-    it('should find an user by id', function(done) {
-      store.read(daisyId).then(function(daisy) {
+    it('should find an user by id', function() {
+      return store.read(daisyId).then(function(daisy) {
         assert(daisy.username === 'daisy');
-      }).then(done).catch(done);
+      });
     });
-    it('should not allow edits', function(done) {
-      store.read(daisyId).then(function(daisy) {
+    it('should not allow edits', function() {
+      return store.read(daisyId).then(function(daisy) {
         daisy.username = 'donald duck';
       }).then(function() {
-        return store.read(daisyId).then(function(daisy2) {
-          assert.equal(daisy2.username, 'daisy',
-            'username should not have been edited');
-        });
-      }).then(done).catch(done);
+        return store.read(daisyId);
+      }).then(function(daisy2) {
+        assert.equal(daisy2.username, 'daisy',
+          'username should not have been edited');
+      });
     });
     it('should error when not found', function(done) {
       store.read('invalid_id').then(function(user) {
         assert(!user);
-      }).then(done).catch(function(err) {
+      }).then(function() {
+        done('should have had an error');
+      }).catch(function(err) {
         assert(err);
         done();
       });
     });
   });
   describe('#byUsername', function() {
-    it('should find an user by username', function(done) {
-      store.byUsername('daisy').then(function(daisy) {
+    it('should find an user by username', function() {
+      return store.byUsername('daisy').then(function(daisy) {
         assert(daisy.username === 'daisy');
-      }).then(done).catch(done);
+      });
     });
-    it('should not allow edits', function(done) {
-      store.byUsername('daisy').then(function(daisy) {
+    it('should not allow edits', function() {
+      return store.byUsername('daisy').then(function(daisy) {
         daisy.username = 'donald duck';
       }).then(function() {
         return store.byUsername('daisy');
       }).then(function(daisy2) {
         assert(daisy2);
-      }).then(done).catch(done);
+      });
     });
     it('should error when not found', function(done) {
       store.byUsername('invalid_username').then(function(user) {
         assert(!user);
-      }).then(done).catch(function(err) {
+      }).then(function() {
+        done('should have had an error');
+      }).catch(function(err) {
         assert(err);
         done();
       });
     });
   });
   describe('#create', function() {
-    it('should add a new user [slow]', function(done) {
+    it('should add a new user [slow]', function() {
       var oldCount;
-      store.list().then(function(orig) {
+      return store.list().then(function(orig) {
         oldCount = orig.length;
         return store.create(userToCreate);
       }).then(function() {
@@ -99,35 +107,35 @@ describe('store', function() {
       }).then(function(newUsers) {
         assert.equal(newUsers.length, oldCount + 1,
           'total users should have increased by 1');
-      }).then(done).catch(done);
+      });
     });
-    it('should generate an id [slow]', function(done) {
-      store.create(userToCreate).then(function(user) {
+    it('should generate an id [slow]', function() {
+      return store.create(userToCreate).then(function(user) {
         assert(user.id);
-      }).then(done).catch(done);
+      });
     });
   });
   describe('#update', function() {
-    it('should update fields', function(done) {
-      store.update({id: daisyId, position: 'test'}).then(function(newDaisy) {
+    it('should update fields', function() {
+      return store.update({id: daisyId, position: 'test'}).then(function(newDaisy) {
         assert.equal(newDaisy.username, 'daisy');
         assert.equal(newDaisy.position, 'test');
-      }).then(done).catch(done);
+      });
     });
     it('should error when not found', function(done) {
       store.update({id: 'invalid_id', position:'test'}).then(function(user) {
         assert(!user);
-      }).then(done).catch(function(err) {
+      }).then(function() {
+        return done('should have had an error');
+      }).catch(function(err) {
         assert(err);
         done();
       });
     });
   });
   describe('#verifyPassword', function() {
-    beforeEach(function(done) {
-      store.create(userToCreate).then(function() {
-        done();
-      });
+    beforeEach(function() {
+      return store.create(userToCreate);
     });
     it('should error when not found', function(done) {
       store.verifyPassword('invalidusername', userToCreate.password).then(function(match) {
@@ -137,61 +145,55 @@ describe('store', function() {
         done();
       });
     });
-    it('should return true on correct password [slow]', function(done) {
-      store.verifyPassword(userToCreate.username, userToCreate.password).then(function(match) {
-        assert(match);
-      }).then(done).catch(done);
+    it('should return true on correct password [slow]', function() {
+      return store.verifyPassword(userToCreate.username, userToCreate.password).then(assert);
     });
-    it('should have a delay on login attempts [slow]', function(done) {
+    it('should have a delay on login attempts [slow]', function() {
       var end;
       var start = hrtime();
-      store.verifyPassword(userToCreate.username, 'nope').catch(function() {
+      return store.verifyPassword(userToCreate.username, 'nope').catch(function() {
         return store.verifyPassword(userToCreate.username, 'nope');
       }).catch(function() {
         end = hrtime();
         return assert(hrtimeDiff(start, end) > 500,
           'should have waited at least 500ms');
-      }).then(done);
+      });
     });
   });
   describe('#updatePassword', function() {
-    beforeEach(function(done) {
-      store.create(userToCreate).then(function() {
-        done();
-      });
+    beforeEach(function() {
+      return store.create(userToCreate);
     });
-    it('should error when user not found', function(done) {
-      store.updatePassword('invalid_username', 'old', 'new').then(function(user) {
-        assert(!user);
-      }).then(done).catch(function(err) {
-        assert(err);
-        done();
-      });
+    it('should error when user not found', function() {
+      return store.updatePassword('invalid_username', 'old', 'new').then(function() {
+        throw new Error('should have had an error');
+      }).catch(assert);
     });
-    it('should error when old password is not correct [slow]', function(done) {
-      store.updatePassword(userToCreate.username, 'nope', 'new').then(done).catch(function(err) {
-        assert(err);
-        done();
-      });
+    it('should error when old password is not correct [slow]', function() {
+      return store.updatePassword(userToCreate.username, 'nope', 'new')
+      .then(function() {
+        throw new Error('should have had an error');
+      }).catch(assert);
     });
-    it('should update the password when the old one is provided [slow]', function(done) {
-      store.updatePassword(userToCreate.username, userToCreate.password, 'new').then(function() {
+    it('should update the password when the old one is provided [slow]', function() {
+      return store.updatePassword(userToCreate.username, userToCreate.password, 'new')
+      .then(function() {
         return store.verifyPassword(userToCreate.username, 'new');
       }).then(function(match) {
         assert(match);
-      }).then(done).catch(done);
+      });
     });
   });
   describe('#delete', function() {
-    it('should remove a user', function(done) {
-      store.delete(daisyId).then(function(user) {
+    it('should remove a user', function() {
+      return store.delete(daisyId).then(function(user) {
         assert.equal(user.username, 'daisy');
-      }).then(done).catch(done);
+      });
     });
-    it('should return null when user not found', function(done) {
-      store.delete('invalid_username').then(function(user) {
+    it('should return null when user not found', function() {
+      return store.delete('invalid_username').then(function(user) {
         assert.equal(user, null);
-      }).then(done).catch(done);
+      });
     });
   });
 });

--- a/lib/user/store.js
+++ b/lib/user/store.js
@@ -1,82 +1,59 @@
 var _ = require('lodash');
-var shortid = require('shortid');
 var hash = require('./hash');
-var ArrayStore = require('fh-wfm-mediator/lib/array-store');
 var q = require('q');
 q.longStackSupport = process.env.NODE_ENV === 'development';
 
 var verifyErrMessage = 'User not found with supplied credentials';
+var Store = require('fh-wfm-simple-store');
 
-function findById(id, data) {
-  return _.find(data, {id: id});
-}
-function findByUsername(username, data) {
-  return _.find(data, {username: username});
-}
-
-function cloneAndCleanup(user) {
-  var cloned = _.clone(user);
-  delete cloned.password;
-  return cloned;
+function stripPassword(user) {
+  user = _.cloneDeep(user);
+  if (user.password) {
+    delete user.password;
+  }
+  return user;
 }
 
-function setUserPassword(user, pwd, cb) {
-  hash.saltAndHash(pwd, function(err, hashed) {
-    if (err) {
-      return cb(err);
-    }
+function hashUserPassword(user, pwd) {
+  return q.nfcall(hash.saltAndHash, pwd).then(function(hashed) {
     user.password = hashed;
-    cb(null, user);
+    return user;
   });
 }
 
-function Store(datasetId, data) {
-  this.data = data;
-  this.topic = {};
-  this.subscription = {};
-  this.datasetId = datasetId;
-}
+const origCreate = Store.prototype.create;
+const origUpdate = Store.prototype.update;
+const origRead = Store.prototype.read;
 
-/**
- * Helper function to reset underlying collection for testing
- */
-Store.prototype.setAll = function(arr) {
-  this.data = arr;
+Store.prototype.create = function(user) {
+  user = _.cloneDeep(user);
+  return hashUserPassword(user, user.password)
+  .then(origCreate.bind(this))
+  .then(stripPassword);
 };
 
-Store.prototype.list = ArrayStore.prototype.list;
-
-/**
- * Finds a user by ID
- */
 Store.prototype.read = function(id) {
-  var user = findById(id, this.data);
-  if (!user) {
-    return q.reject(new Error('User not found'));
-  }
-  return q(cloneAndCleanup(user));
+  return origRead.call(this, id).then(function(user) {
+    if (!user) {
+      throw new Error('User not found');
+    }
+    return user;
+  });
+};
+
+Store.prototype.findByUsername = function(username) {
+  return this.list({
+    key: 'username',
+    value: username
+  }).then(_.first);
 };
 
 /**
  * Finds a user by username.
  */
 Store.prototype.byUsername = function(username) {
-  var user = findByUsername(username, this.data);
-  if (!user) {
-    return q.reject(new Error('User not found'));
-  }
-  return q(cloneAndCleanup(user));
-};
-
-
-Store.prototype.create = function(user) {
-  user = _.clone(user);
-  user.id = shortid.generate();
-  var self = this;
-  return q.nfcall(setUserPassword, user, user.password).then(function(user) {
-    self.data.push(user);
-    return cloneAndCleanup(user);
-  });
+  return this.findByUsername(username, this.data)
+  .then(stripPassword);
 };
 
 /**
@@ -87,15 +64,10 @@ Store.prototype.create = function(user) {
  * @return {Promise}      Promise that resolves to the updated user
  */
 Store.prototype.update = function(user) {
-  var originalUser = findById(user.id, this.data);
-  if (!originalUser) {
-    return q.reject(new Error('User not found'));
-  }
-  delete user.id;
-  _.assign(originalUser, user);
-  // update password since this should only be called from the portal
-  var passwordPromise = user.password ? q.nfcall(setUserPassword, originalUser, user.password) : q(originalUser);
-  return passwordPromise.then(cloneAndCleanup);
+  var passwordPromise = user.password ? hashUserPassword(user, user.password) : q(user);
+  return passwordPromise
+  .then(origUpdate.bind(this))
+  .then(stripPassword);
 };
 
 /**
@@ -108,18 +80,22 @@ Store.prototype.update = function(user) {
  * Note that the password field is not readable
  */
 Store.prototype.updatePassword = function(username, oldPwd, newPwd) {
-  var user = findByUsername(username, this.data);
-  if (!user) {
-    return q.reject(new Error(verifyErrMessage));
-  }
-  return q.nfcall(hash.verify, oldPwd, user.password).then(function(match) {
+  var user;
+  return this.findByUsername(username).then(function(found) {
+    return user = found;
+  })
+  .then(_.partial(doVerify, oldPwd))
+  .then(function(match) {
     if (!match) {
-      throw new Error();
+      return q.reject();
     }
-    return q.nfcall(setUserPassword, user, newPwd);
-  }).then(function(user) {
-    return cloneAndCleanup(user);
-  }).catch(function() {
+    // old password matches, update to new password
+    user.password = newPwd;
+    return user;
+  })
+  .then(this.update.bind(this))
+  .then(stripPassword)
+  .catch(function() {
     return q.reject(new Error(verifyErrMessage));
   });
 };
@@ -143,57 +119,14 @@ function doVerify(password, user) {
  * the promise is also rejected if the user is not found or the password does not match
  */
 Store.prototype.verifyPassword = function(username, password) {
-  var user = findByUsername(username, this.data);
-  if (!user) {
+  return this.findByUsername(username)
+  .then(function(user) {
+    return q.delay(user, 500);
+  })
+  .then(_.partial(doVerify, password))
+  .catch(function() {
     return q.reject(new Error(verifyErrMessage));
-  }
-  var delay = 500;
-  return q.delay(delay).then(function() {
-    return doVerify(password, user);
   });
-};
-
-Store.prototype.delete = ArrayStore.prototype.delete;
-
-Store.prototype.listen = function(topicPrefix, mediator) {
-  var self = this;
-  ArrayStore.prototype.listen.apply(this, arguments);
-  // subscribe to extra topics
-  self.topic.usernameLoad = 'wfm:user:username:read';
-  console.log('Subscribing to mediator topic:', self.topic.usernameLoad);
-  self.subscription.usernameLoad = mediator.subscribe(self.topic.usernameLoad, function(username) {
-    self.byUsername(username).then(function(user) {
-      mediator.publish('done:' + self.topic.usernameLoad + ':' + username, user);
-    }).catch(function(err) {
-      mediator.publish('error:' + self.topic.usernameLoad + ':' + username, err);
-    });
-  });
-  self.topic.auth = 'wfm:user:auth';
-  console.log('Subscribing to mediator topic:', self.topic.auth);
-  self.subscription.auth = mediator.subscribe(self.topic.auth, function(data) {
-    self.verifyPassword(data.username, data.password).then(function(passwordCorrect) {
-      mediator.publish('done:' + self.topic.auth + ':' + data.username, passwordCorrect);
-    }).catch(function(err) {
-      mediator.publish('error:' + self.topic.auth + ':' + data.username, err.message);
-    });
-  });
-  self.topic.passwordEdit = 'wfm:user:password';
-  console.log('Subscribing to mediator topic:', self.topic.passwordEdit);
-  self.subscription.passwordEdit = mediator.subscribe(self.topic.passwordEdit, function(data) {
-    self.updatePassword(data.username, data.oldPwd, data.newPwd).then(function(user) {
-      mediator.publish('done:' + self.topic.passwordEdit + ':' + data.username, user);
-    }).catch(function(err) {
-      mediator.publish('error:' + self.topic.passwordEdit + ':' + data.username, err.message);
-    });
-  });
-};
-
-Store.prototype.unsubscribe = function() {
-  ArrayStore.prototype.unsubscribe.apply(this, arguments);
-  // unsubscribe extra topics
-  this.mediator.remove(this.topic.usernameLoad, this.subscription.usernameLoad.id);
-  this.mediator.remove(this.topic.auth, this.subscription.auth.id);
-  this.mediator.remove(this.topic.passwordEdit, this.subscription.passwordEdit.id);
 };
 
 module.exports = Store;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express": "4.14.0",
     "express-session": "^1.14.2",
     "fh-mbaas-api": "5.14.2",
-    "fh-wfm-mediator": "0.0.15",
+    "fh-wfm-mediator": "0.1.0-rc1",
     "fh-wfm-simple-store": "0.0.1",
     "lodash": "4.7.0",
     "mongodb": "^2.2.16",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express-session": "^1.14.2",
     "fh-mbaas-api": "5.14.2",
     "fh-wfm-mediator": "0.1.0-rc1",
-    "fh-wfm-simple-store": "0.0.1",
+    "fh-wfm-simple-store": "0.0.2",
     "lodash": "4.7.0",
     "mongodb": "^2.2.16",
     "q": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "wfm-template-build -m 'wfm.user.directives'",
     "watch": "wfm-template-build -w -m 'wfm.user.directives'",
+    "vuln": "nsp check",
     "test": "cross-env WFM_USE_MEMORY_STORE=true grunt"
   },
   "keywords": [
@@ -39,8 +40,9 @@
     "grunt-mocha-test": "^0.13.2",
     "grunt-shell": "1.2.1",
     "load-grunt-tasks": "^3.5.2",
-    "proxyquire": "^1.7.10",
     "mocha": "^3.2.0",
+    "nsp": "^2.6.2",
+    "proxyquire": "^1.7.10",
     "sinon": "^1.17.6",
     "sinon-as-promised": "^4.0.2",
     "supertest": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "wfm-template-build -m 'wfm.user.directives'",
     "watch": "wfm-template-build -w -m 'wfm.user.directives'",
-    "test": "grunt"
+    "test": "cross-env WFM_USE_MEMORY_STORE=true grunt"
   },
   "keywords": [
     "wfm",
@@ -21,6 +21,7 @@
     "express-session": "^1.14.2",
     "fh-mbaas-api": "5.14.2",
     "fh-wfm-mediator": "0.0.15",
+    "fh-wfm-simple-store": "0.0.1",
     "lodash": "4.7.0",
     "mongodb": "^2.2.16",
     "q": "1.4.1",
@@ -31,14 +32,15 @@
   "devDependencies": {
     "body-parser": "^1.15.2",
     "cookie-parser": "^1.4.3",
+    "cross-env": "^3.1.3",
     "fh-wfm-template-build": "0.0.9",
     "grunt": "^1.0.1",
     "grunt-eslint": "^18.0.0",
     "grunt-mocha-test": "^0.13.2",
     "grunt-shell": "1.2.1",
     "load-grunt-tasks": "^3.5.2",
-    "mocha": "2.4.5",
     "proxyquire": "^1.7.10",
+    "mocha": "^3.2.0",
     "sinon": "^1.17.6",
     "sinon-as-promised": "^4.0.2",
     "supertest": "^2.0.1"


### PR DESCRIPTION
# Motivation
Utilize the new store implementation to allow for in-memory and mongodb storage

# Changes
- Add fh-wfm-simple-store
- Bump mediator to `0.1.0-rc1` version (needs to be changed for release)
- Update mocha
- Update `lib/user/store.js` to delegate to simple-store
- Update unit tests to target simple-store