### PR TITLE
Defined session token expiry value in config file

### DIFF
--- a/lib/middleware/sessionCache.js
+++ b/lib/middleware/sessionCache.js
@@ -31,7 +31,7 @@ function saveSession(mbaasApi, sessionToken, session, cb) {
   var options = {
     "act": "save",
     "key": sessionToken,
-    "expire": config.expiry || 1800,
+    "expire": config.sessionTokenExpiry,
     "value": JSON.stringify(session)
   };
 

--- a/lib/user/config-user.js
+++ b/lib/user/config-user.js
@@ -5,5 +5,6 @@ module.exports = {
   apiPath: '/api/wfm/user',
   authpolicyPath: '/box/srv/1.1/admin/authpolicy',
   policyId: process.env.WFM_AUTH_POLICY_ID || 'wfm',
-  defaultAuthResponseExclusionList: ['password']
+  defaultAuthResponseExclusionList: ['password'],
+  sessionTokenExpiry: 1800
 };


### PR DESCRIPTION
Moved session token expiry value to be defined in the config file instead. 