### PR TITLE
[Raincatch 510] Fix mongo session storage

### DIFF
--- a/lib/middleware/validateSession.js
+++ b/lib/middleware/validateSession.js
@@ -18,7 +18,6 @@ module.exports = function validateSession(mediator, mbaasApi, excludePaths) {
     //gets session and session token from fh_params.
     var session = req.fh_params || {__fh: {}};
     var sessionToken = session.__fh.sessiontoken || session.__fh.sessionToken;
-
     var curPath = req.path;
 
 

--- a/lib/router/mbaas-session-middleware-spec.js
+++ b/lib/router/mbaas-session-middleware-spec.js
@@ -1,0 +1,48 @@
+'use strict';
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+// setup proxies for module under test
+const mongoProviderProxy = {
+  init: sinon.stub().callsArg(2)
+};
+const redisProviderProxy = {
+  init: sinon.stub().callsArg(2)
+};
+const mbaasSessionMiddleware = proxyquire('./mbaas-session-middleware', {
+  '../session/mongoProvider': mongoProviderProxy,
+  '../session/redisProvider': redisProviderProxy
+});
+
+describe('mbaas-session-middleware', function() {
+  describe('#addConfigDefaults', function() {
+    describe('for redis', function() {
+      it('should supply localhost:6379 as a default', function(done) {
+        mbaasSessionMiddleware.init({
+          store: 'redis'
+        }, function() {
+          assert(redisProviderProxy.init.calledWithMatch({
+            config: {
+              host: sinon.match.string,
+              port: sinon.match.string
+            }
+          }));
+          return done();
+        });
+      });
+    });
+    describe('for mongodb', function() {
+      it('should use a localhost url by default', function(done) {
+        mbaasSessionMiddleware.init({
+          store: 'mongo'
+        }, function() {
+          assert(mongoProviderProxy.init.calledWithMatch({
+            config: { url: sinon.match.string }
+          }));
+          return done();
+        });
+      });
+    });
+  });
+});

--- a/lib/router/mbaas-session-middleware.js
+++ b/lib/router/mbaas-session-middleware.js
@@ -1,6 +1,6 @@
 var session = require('express-session');
 var _ = require('lodash');
-var sessionProviders = require('../session');
+var path = require('path');
 var provider;
 
 /**
@@ -15,23 +15,13 @@ function init(sessionConfig, cb) {
   }
 
   sessionConfig.store = sessionConfig.store || 'redis';
-  provider = sessionProviders[sessionConfig.store];
-  if (!provider) {
+  try {
+    provider = require(path.join('../session/', sessionConfig.store + 'Provider'));
+  } catch (e) {
     return cb(new Error("Session Storage Provider is not supported."), null);
   }
 
-  var expressSessionConfig = _.defaults(sessionConfig, {
-    config: _.defaults({
-      secret: process.env.FH_COOKIE_SECRET || 'raincatcher',
-      resave: false,
-      saveUninitialized: true,
-      cookie: {
-        secure: process.env.NODE_ENV !== 'development',
-        httpOnly: true,
-        path: '/'
-      }
-    }, provider.defaultConfig)
-  });
+  var expressSessionConfig = addConfigDefaults(sessionConfig);
 
   var config = {session: session, options: expressSessionConfig};
   return provider.init(expressSessionConfig, session, function(err) {
@@ -70,6 +60,21 @@ function revokeSession(req, res, next) {
   }
 
   provider.revokeSession(sessionId, next);
+}
+
+function addConfigDefaults(config) {
+  return _.defaults(config, {
+    config: _.defaults({
+      secret: process.env.FH_COOKIE_SECRET || 'raincatcher',
+      resave: false,
+      saveUninitialized: true,
+      cookie: {
+        secure: process.env.NODE_ENV !== 'development',
+        httpOnly: true,
+        path: '/'
+      }
+    }, provider.defaultConfig)
+  });
 }
 
 module.exports = {

--- a/lib/router/mbaas-session-middleware.js
+++ b/lib/router/mbaas-session-middleware.js
@@ -63,8 +63,8 @@ function revokeSession(req, res, next) {
 }
 
 function addConfigDefaults(config) {
-  return _.defaults(config, {
-    config: _.defaults({
+  return _.defaultsDeep(config, {
+    config: {
       secret: process.env.FH_COOKIE_SECRET || 'raincatcher',
       resave: false,
       saveUninitialized: true,
@@ -73,7 +73,9 @@ function addConfigDefaults(config) {
         httpOnly: true,
         path: '/'
       }
-    }, provider.defaultConfig)
+    }
+  }, {
+    config: provider.defaultConfig
   });
 }
 

--- a/lib/router/mbaas.js
+++ b/lib/router/mbaas.js
@@ -6,20 +6,35 @@ var userAuth = require('./mbaas-auth');
 var sessionMiddleware = require('./mbaas-session-middleware');
 var _ = require('lodash');
 
-function initRouter(mediator, authResponseExclusionList) {
+function initRouter(mediator, authResponseExclusionList, expressSessionMiddleware) {
   var router = express.Router();
 
   router.all('/auth', function(req, res) {
     var params = req.body;
     var userId = params && params.userId || params.username;
-    if (userId) {
 
-      // try to authenticate
-      userAuth.auth(mediator, userId, params.password)
-        .then(function(profileData) {
-          // trim the authentication response to remove specified fields
-          var authResponse = trimAuthResponse(profileData, authResponseExclusionList);
-          // on success pass relevant data into response
+    //If there is no userId, then we cannot authenticate.
+    if (!userId) {
+      console.log('No username provided');
+      res.status(400);
+      return res.json({message: 'Invalid credentials'});
+    }
+
+    // try to authenticate
+    userAuth.auth(mediator, userId, params.password)
+      .then(function(profileData) {
+        // trim the authentication response to remove specified fields
+        var authResponse = trimAuthResponse(profileData, authResponseExclusionList);
+        // on success pass relevant data into response
+
+        //Using express-session to generate and store a session.
+        //This is only done for authenticated requests. Otherwise we don't generate a session
+        //as it would cause a session to be created for every request.
+        expressSessionMiddleware(req, res, function(err) {
+          //An error occurred while trying to create a valid session token for the user.
+          if (err) {
+            return res.status(500).json({message: "Unexpected error when creating a session. Please try again."});
+          }
 
           res.status = 200;
           res.json({
@@ -28,20 +43,15 @@ function initRouter(mediator, authResponseExclusionList) {
             sessionToken: req.sessionID,
             authResponse: authResponse
           });
-        })
-        .catch(function(err) {
-          // on error pass error message into response body, assign 401 http code.
-          // 401 - invalid credentials (unauthorised)
-          res.status(401);
-          res.json(err.message ? err.message : 'Invalid Credentials');
         });
-    } else {
-      console.log('No username provided');
-      res.status(400);
-      res.json({message: 'Invalid credentials'});
-    }
-  })
-  ;
+      })
+      .catch(function(err) {
+        // on error pass error message into response body, assign 401 http code.
+        // 401 - invalid credentials (unauthorised)
+        res.status(401);
+        res.json(err.message ? err.message : 'Invalid Credentials');
+      });
+  });
 
   router.all('/verifysession', sessionMiddleware.verifySession, function(req, res) {
     res.json({
@@ -110,17 +120,23 @@ function trimAuthResponse(authResponse, exclusionList) {
 }
 
 function init(mediator, app, authResponseExclusionList, sessionOptions, cb) {
-  var router = initRouter(mediator, authResponseExclusionList);
+
   sessionMiddleware.init(sessionOptions, function(err, result) {
     if (err) {
       return cb(err);
     }
-    app.use(result.session({
+
+    //Creating the express-session middleware using the redis or mongo database.
+    var expressSessionMiddleware = result.session({
       secret: result.options.config.secret,
       store: result.store,
       resave: result.options.config.resave,
       saveUninitialized: result.options.config.saveUninitialized
-    }));
+    });
+
+
+    //The express session is only used for authentication responses
+    var router = initRouter(mediator, authResponseExclusionList, expressSessionMiddleware);
     app.use(config.apiPath, router);
     return cb();
   });

--- a/lib/session/index.js
+++ b/lib/session/index.js
@@ -1,2 +1,0 @@
-exports.mongo = require('./mongoProvider.js');
-exports.redis = require('./redisProvider.js');

--- a/lib/session/mongoProvider.js
+++ b/lib/session/mongoProvider.js
@@ -26,7 +26,6 @@ module.exports = {
     }, cb);
   },
   defaultConfig: {
-    db: 'session',
     url: 'mongodb://localhost:27017/raincatcher-demo-auth-session-store'
   }
 };

--- a/lib/session/mongoProvider.js
+++ b/lib/session/mongoProvider.js
@@ -13,10 +13,12 @@ module.exports = {
     });
   },
   verifySession: function(token, cb) {
-    this.db.collection('sessions').find({
+    //For a given session token, there should only be a maximum of 1
+    this.db.collection('sessions').findOne({
       '_id': token
-    }, function(err, doc) {
-      var valid = !err && doc && doc.expires < new Date();
+    }, function(err, foundSession) {
+      //For the session to be valid, the expiry date must be greater than now.
+      var valid = !err && foundSession &&  new Date() < new Date(foundSession.expires);
       return cb(err, valid);
     });
   },

--- a/lib/session/mongoProvider.js
+++ b/lib/session/mongoProvider.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   verifySession: function(token, cb) {
     this.db.collection('sessions').find({
-      '_id': {'$eq': token}
+      '_id': token
     }, function(err, doc) {
       var valid = !err && doc && doc.expires < new Date();
       return cb(err, valid);
@@ -22,7 +22,7 @@ module.exports = {
   },
   revokeSession: function(token, cb) {
     this.db.collection('sessions').deleteOne({
-      '_id': {'$eq': token}
+      '_id': token
     }, cb);
   },
   defaultConfig: {

--- a/lib/session/mongoProvider.js
+++ b/lib/session/mongoProvider.js
@@ -3,11 +3,11 @@ module.exports = {
   init: function(expressConfig, session, cb) {
     var self = this;
     var MongoStore = require('connect-mongo')(session);
-    this.store = new MongoStore(expressConfig.config);
     MongoClient.connect(expressConfig.config.url, function(err, mongo) {
       if (err) {
         return cb(err);
       }
+      self.store = new MongoStore({db: mongo});
       self.db = mongo;
       return cb(null);
     });
@@ -26,8 +26,6 @@ module.exports = {
     }, cb);
   },
   defaultConfig: {
-    host: '127.0.0.1',
-    port: '27017',
     db: 'session',
     url: 'mongodb://localhost:27017/raincatcher-demo-auth-session-store'
   }


### PR DESCRIPTION
# Motivation
Mongodb session storage had a wrong default configuration

# Changes
- Add unit tests for defaults on session storage providers
- Fix defaults for storage providers
- Use single MongoClient inside connect-mongo and outside