### PR TITLE
Added LocalStrorage Profile Data Security

### DIFF
--- a/lib/security/aes.js
+++ b/lib/security/aes.js
@@ -1,0 +1,42 @@
+var CryptoJS = require("crypto-js");
+var q = require('q');
+
+/**
+* Encrypt an Object using AES with a specified secret key.
+* @param data - the data to encrypt.
+* @param key - the secret key to encrypt with.
+*/
+function encrypt(data, key) {
+  var deferred = q.defer();
+
+  if (data === null || key === null) {
+    deferred.reject(new Error("Data or Secret key is Null."));
+  } else {
+    var ciphertext = CryptoJS.AES.encrypt(JSON.stringify(data), key);
+    deferred.resolve(ciphertext);
+  }
+  return deferred.promise;
+}
+
+/**
+* Decrypt some ciphertext using AES with a specified secret key.
+* @param ciphertext - the ciphertext to decrypt.
+* @param key - the secret key to decrypt with.
+*/
+function decrypt(ciphertext, key) {
+  var deferred = q.defer();
+
+  if (ciphertext === null || key === null) {
+    deferred.reject(new Error("Ciphertext or Secret key is Null."));
+  } else {
+    var bytes  = CryptoJS.AES.decrypt(ciphertext.toString(), key);
+    var decryptedData = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
+    deferred.resolve(decryptedData);
+  }
+  return deferred.promise;
+}
+
+module.exports = {
+  encrypt: encrypt,
+  decrypt: decrypt
+};

--- a/lib/security/security-spec.js
+++ b/lib/security/security-spec.js
@@ -1,0 +1,70 @@
+var assert = require('assert');
+var sampleUserProfileData = require('../../test/fixtures/sampleUserProfile.json');
+var aes = require('./aes.js');
+var sha256 = require('./sha256.js');
+var sampleSecurityeData = require('../../test/fixtures/sampleSecurityData.json');
+
+describe("Test Data Encyption, Hashing and Decryption", function() {
+  it('should error when you try to hash a null value', function(done) {
+    return sha256.hash(null).then(function(response) {
+      assert(!response, "Should not contain a hash value,");
+    }).then(done).catch(function(err) {
+      assert(err, "should contain an error.");
+      done();
+    });
+  });
+
+  it('should respond with a correct hash when you try to hash a string value', function(done) {
+    sha256.hash(sampleSecurityeData.plaintext).then(function(response) {
+      assert.equal(response, sampleSecurityeData.plaintextSha256);
+    }).then(done);
+  });
+
+  it('should error when you try to encrypt using a null data value', function(done) {
+    aes.encrypt(null, sampleSecurityeData.aesKey).then(function() {
+      done(new Error('It should not try to encrypt using a null data value'));
+    }, function(err) {
+      assert(err, "should contain an error.");
+      done();
+    });
+  });
+
+  it('should error when you try to encrypt using a null secret key value', function(done) {
+    aes.encrypt(sampleUserProfileData, null).then(function() {
+      done(new Error('It should not try to encrypt using a null secret key value'));
+    }, function(err) {
+      assert(err, "should contain an error.");
+      done();
+    });
+  });
+
+  it('should respond with ciphertext when you try to encrypt a string value', function(done) {
+    aes.encrypt(sampleUserProfileData, sampleSecurityeData.aesKey).then(function(response) {
+      assert.equal(response.toString().length, sampleSecurityeData.ciphertextLength, "It should match the specified ciphertext length");
+    }).then(done).catch(done);
+  });
+
+  it('should error when you try to decrypt using a null ciphertext value', function(done) {
+    aes.decrypt(null, sampleSecurityeData.aesKey).then(function(response) {
+      assert(!response);
+    }).then(done).catch(function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should error when you try to decrypt using a null secret key value', function(done) {
+    aes.decrypt(sampleUserProfileData, null).then(function(response) {
+      assert(!response);
+    }).then(done).catch(function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should respond with the correct plaintext when you try to decrypt some ciphertext', function(done) {
+    aes.decrypt(sampleSecurityeData.sampleUserProfileDataCiphertext, sampleSecurityeData.aesKey).then(function(response) {
+      assert.equal(JSON.stringify(sampleUserProfileData), JSON.stringify(response), "It should match the specified plaintext");
+    }).then(done).catch(done);
+  });
+});

--- a/lib/security/sha256.js
+++ b/lib/security/sha256.js
@@ -1,0 +1,21 @@
+var CryptoJS = require("crypto-js");
+var q = require('q');
+
+/**
+* Generate a SHA256 hash value for some given text.
+* @param text - the text to generate a hash value for,
+*/
+function hash(text) {
+  var deferred = q.defer();
+  if (text === null) {
+    deferred.reject(new Error("Text to hash is Null."));
+  } else {
+    var hash = CryptoJS.SHA256(text);
+    deferred.resolve(hash.toString(CryptoJS.enc.Base64));
+  }
+  return deferred.promise;
+}
+
+module.exports = {
+  hash: hash
+};

--- a/lib/user/mocks/user-client-mock.js
+++ b/lib/user/mocks/user-client-mock.js
@@ -1,0 +1,24 @@
+var sinon = require('sinon');
+require('sinon-as-promised');
+var sampleSecurityData = require('../../../test/fixtures/sampleSecurityData.json');
+
+/**
+* Simple function to mock the logic for profile data encryption without using phantom/jsdom to mock localstorage interactions.
+* The tests for the underlying security functionality is found in lib/security
+* @param profileData - the users profile data
+* @param sessionToken - the users sessionToken
+*/
+function storeProfileStub(profileData, sessionToken) {
+  var stub = sinon.stub();
+  if (profileData === null || sessionToken === null) {
+    stub.rejects(new Error("Session Token or Profile Data is Null. Setting profile data to null."));
+  } else {
+    // return some ciphertext
+    stub.resolves(sampleSecurityData.sampleUserProfileDataCiphertext);
+  }
+  return stub;
+}
+
+module.exports = {
+  storeProfile: storeProfileStub()
+};

--- a/lib/user/user-client-spec.js
+++ b/lib/user/user-client-spec.js
@@ -1,0 +1,44 @@
+var assert = require('assert');
+var userClientMock = require('./mocks/user-client-mock');
+var sinon = require('sinon');
+var sampleUserProfileData = require('../../test/fixtures/sampleUserProfile.json');
+var sampleSecurityData = require('../../test/fixtures/sampleSecurityData.json');
+
+describe("Test Storage/Retrieval of Profile Data", function() {
+
+  it('Should return ciphertext when the profile data and the session token are valid', function() {
+    return userClientMock.storeProfile(sampleUserProfileData, sampleSecurityData.sessionToken).then(function(result, err) {
+      sinon.assert.calledWith(userClientMock.storeProfile, sampleUserProfileData, sampleSecurityData.sessionToken);
+      assert.ok(!err, 'Error on valid credentials ' + err);
+      assert.ok(result, "Expected a result from the request.");
+      assert.equal(result, sampleSecurityData.sampleUserProfileDataCiphertext);
+    });
+  });
+
+  it('Should not attempt Encyption when the profileData is null', function() {
+    return userClientMock.storeProfile(null, sampleSecurityData.sessionToken).then(function(err, result) {
+      sinon.assert.calledWith(userClientMock.storeProfile, null, sampleSecurityData.sessionToken);
+      assert.ok(!result, "Did not expect a result from the request.");
+      assert(err, "should contain an error.");
+    });
+  });
+
+  it('Should not attempt Encyption when the sessionToken is null', function() {
+    return userClientMock.storeProfile(sampleUserProfileData, null).then(function(err, result) {
+      sinon.assert.calledWith(userClientMock.storeProfile, sampleUserProfileData, null);
+      assert.ok(!result, "Did not expect a result from the request.");
+      assert(err, "should contain an error.");
+    });
+  });
+
+  it('Should not attempt Encyption when both the profileData and the sessionToken are null', function() {
+    return userClientMock.storeProfile(null, null).then(function(err, result) {
+      sinon.assert.calledWith(userClientMock.storeProfile, null, null);
+      assert.ok(!result, "Did not expect a result from the request.");
+      assert(err, "should contain an error.");
+    });
+  });
+
+
+
+});

--- a/lib/user/user-client.js
+++ b/lib/user/user-client.js
@@ -3,6 +3,8 @@
 var q = require('q');
 var _ = require('lodash');
 var config = require('./config-user');
+var aes = require('../security/aes');
+var sha256 = require('../security/sha256');
 var policyId;
 
 var UserClient = function(mediator) {
@@ -29,13 +31,67 @@ var xhr = function(_options) {
   return deferred.promise;
 };
 
-var storeProfile = function(profileData) {
-  localStorage.setItem('fh.wfm.profileData', JSON.stringify(profileData));
+/**
+* Encrypt the users profile data using AES with a hash of the session key and store the result in localStorage.
+* @param profileData - the plaintext to encrypt.
+* @param sessionToken - the secret key to encrypt with.
+*/
+var storeProfile = function(profileData, sessionToken) {
+  var deferred = q.defer();
+  if (sessionToken !== null && profileData !== null) {
+    sha256.hash(sessionToken).then(function(hash) {
+      aes.encrypt(profileData, hash).then(function(ciphertext) {
+        localStorage.setItem('fh.wfm.profileData', ciphertext);
+        return deferred.resolve();
+      }, function(err) {
+        console.log("Could not encrypt the data.", err);
+        localStorage.setItem('fh.wfm.profileData', null);
+        return deferred.reject();
+      }
+      );
+    }, function(err) {
+      console.log("Could not generate hash value for the session token", err);
+      localStorage.setItem('fh.wfm.profileData', null);
+      return deferred.reject();
+    });
+  } else {
+    console.log("Session Token or Profile Data is Null. Setting profile data to null.");
+    localStorage.setItem('fh.wfm.profileData', null);
+    return deferred.reject();
+  }
+  return deferred.promise;
 };
 
+/**
+* Decrypt the users profile data using AES with a hash of the session key.
+*/
+
 var retrieveProfileData = function() {
-  var json = localStorage.getItem('fh.wfm.profileData');
-  return json ? JSON.parse(json) : null;
+  var deferred = q.defer();
+  if (localStorage.getItem('fh_session_token.sessionToken') === null) {
+    console.log("Error: Session Token is Undefined, Cannot Retrieve Profile Data.");
+    return deferred.reject(null);
+  } else if (localStorage.getItem('fh.wfm.profileData') === null) {
+    console.log("Error: Profile Data is Null. Cannot Retrieve Profile Data.");
+    return deferred.reject(null);
+  }
+
+  var ciphertext = localStorage.getItem('fh.wfm.profileData');
+  var sessionToken = JSON.parse(localStorage.getItem('fh_session_token.sessionToken')).sessionToken;
+
+  sha256.hash(sessionToken).then(function(hash) {
+    aes.decrypt(ciphertext, hash).then(function(plaintext) {
+      return deferred.resolve(plaintext);
+    }, function(err) {
+      console.log("Could not decrypt the data. Cannot Retrieve Profile Data.", err);
+      return deferred.reject(null);
+    }
+  );
+  }, function(err) {
+    console.log("Could not generate hash value for the session token. Cannot Retrieve Profile Data.", err);
+    return deferred.reject(null);
+  });
+  return deferred.promise;
 };
 
 UserClient.prototype.init = function() {
@@ -109,6 +165,7 @@ UserClient.prototype.auth = function(username, password) {
     }, function(res) {
       // res.sessionToken; // The platform session identifier
       // res.authResponse; // The authetication information returned from the authetication service.
+      var sessionToken = res.sessionToken;
       var profileData = res.authResponse;
       if (typeof profileData === 'string' || profileData instanceof String) {
         try {
@@ -119,9 +176,11 @@ UserClient.prototype.auth = function(username, password) {
           profileData = JSON.parse(profileData.replace(/,\s/g, ',').replace(/[^,={}]+/g, '"$&"').replace(/=/g, ':'));
         }
       }
-      storeProfile(profileData);
-      self.mediator.publish('wfm:auth:profile:change', profileData);
-      deferred.resolve(res);
+      storeProfile(profileData, sessionToken).then(function() {
+        self.mediator.publish('wfm:auth:profile:change', profileData);
+        deferred.resolve(res);
+      });
+
     }, function(msg, err) {
       console.log(msg, err);
       var errorMsg = err.message;
@@ -171,7 +230,7 @@ UserClient.prototype.clearSession = function() {
       console.log('Failed to clear session: ', err);
       deferred.reject(err);
     } else {
-      storeProfile(null);
+      storeProfile(null, null);
       self.mediator.publish('wfm:auth:profile:change', null);
       deferred.resolve(true);
     }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "connect-mongo": "^1.3.2",
     "connect-redis": "^3.1.0",
+    "crypto-js": "^3.1.9-1",
     "express": "4.14.0",
     "express-session": "^1.14.2",
     "fh-mbaas-api": "5.14.2",

--- a/test/fixtures/sampleSecurityData.json
+++ b/test/fixtures/sampleSecurityData.json
@@ -1,0 +1,8 @@
+{
+  "sessionToken": "secret_token",
+  "plaintext": "plaintext",
+  "plaintextSha256": "ltYuKr0+Qt5fUDMPuO/ExVmYNSeAd7IemqCzPB3wehw=",
+  "aesKey":"secret",
+  "ciphertextLength": 556,
+  "sampleUserProfileDataCiphertext": "U2FsdGVkX19wiZrKkC+r+4BvhuhJq0LuNd0lLOBtFOShIgtmy0SFrZQBYNeDkuMvYUna1NalSzXbqxAYmWUPMPELXWf71MzLvBlFrLnviCya759l7bfPUAqaW0lUexLQOJLU6x3CvVGWPzHlZkYkTBmmx0Du6tIaFdKYs6kBeMNXjCmcSvpyzmTxxSqB1DtoVk08/gz/cWdse+AuXCp8YnRZFkvPa4v3dF+oqX3RvHI/CJgbqZ6sP1mzRmkYF7wbuUhJjhaaksrrd46Gh6pYai+AqN8c0gaAzb3flfL1Sw0KWQDDMaK0VQwRZhCD6SyRXa6ChBKMdw9LMo8iSFXYXl7vtNE6cmU5Ol4Uy6EXdBud32U7jDgTo6v+meG8x1rdIHqrND8tXa5Sjl8xaZt310vJBIKm08usiSdKcgcJOSYaDqQtZLG2klwWdMEFfKcdBn4FN4kS5MYPBrPjt0qHedvVyCa1Pvm95tGUN5U/kvU2gJBqbEPnn9UJJ49D568O9tNVRpbRNB3xCzPRcDtQcOTlRzuHoM0sumCCqjh5j6k="
+}


### PR DESCRIPTION
**Motivation**
Sensitive worker information (eg. messages, email addresses) are being stored in plaintext format in localstorage on a device. This information can be extracted from a device very easily. Recoverable under `/data/data/com.app.name` in Android. 

The Profile Data is being encrypted using AES-256 in CBC mode with the secret key being a SHA256 of the users current session key when they login. The profile data is wiped when the user logs out. The security functionality is broken out into separate files under /security so it can be reused again for other uses in the future. If the session key or profile data returned in the auth response is null, the profileData will be set to null in localstorage, as before.

The users messages which come from sync are not being encypted as part of this change as Sync is handling the storage/retrieval of the messages itself and can't be changed from raincatcher-user. Similarly, the session token is not being encrypted as this will be stored in a cookie in the future.

**JIRA Ticket**
https://issues.jboss.org/browse/RAINCATCH-409