### PR TITLE
Add localstorage profileData security

### DIFF
--- a/lib/security/aes.js
+++ b/lib/security/aes.js
@@ -1,0 +1,40 @@
+var CryptoJS = require("crypto-js");
+
+/**
+* Encrypt an Object using AES with a specified secret key.
+* @param {object} data - the data to encrypt.
+* @param {string} key - the secret key to encrypt with.
+* @returns {string} ciphertext
+*/
+function encrypt(data, key) {
+  if (!data || !key) {
+    throw Error("Cannot Encrypt Profile Data - Data or Secret key is Null.");
+  }
+  return CryptoJS.AES.encrypt(JSON.stringify(data), key);
+}
+
+/**
+* Decrypt some ciphertext using AES with a specified secret key.
+* @param {string} ciphertext - the ciphertext to decrypt.
+* @param {string} key - the secret key to decrypt with.
+* @returns {string/object} plaintext
+*/
+function decrypt(ciphertext, key) {
+
+  if (!ciphertext || !key) {
+    throw Error("Cannot Decrypt Profile Data - Ciphertext or Secret key is Null.");
+  }
+
+  var bytes  = CryptoJS.AES.decrypt(ciphertext.toString(), key);
+  try {
+    JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
+  } catch (e) {
+    return bytes.toString(CryptoJS.enc.Utf8);
+  }
+  return JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
+}
+
+module.exports = {
+  encrypt: encrypt,
+  decrypt: decrypt
+};

--- a/lib/security/security-spec.js
+++ b/lib/security/security-spec.js
@@ -1,0 +1,54 @@
+var assert = require('assert');
+var sampleUserProfileData = require('../../test/fixtures/sampleUserProfile.json');
+var aes = require('./aes.js');
+var sha256 = require('./sha256.js');
+var sampleSecurityData = require('../../test/fixtures/sampleSecurityData.json');
+
+describe("Test Data Encyption, Hashing and Decryption", function() {
+  it('should error when you try to hash a null value', function() {
+    assert.throws(function() {
+      sha256.hash(null);
+    }, Error );
+  });
+
+  it('should respond with a correct hash when you try to hash a string value', function() {
+    var hash = sha256.hash(sampleSecurityData.plaintext);
+    assert.equal(false, (hash instanceof Error), 'Should not return an error.');
+    assert.equal(sampleSecurityData.plaintextSha256, hash, 'Should return the expected hash value.');
+  });
+
+  it('should error when you try to encrypt using a null data value', function() {
+    assert.throws(function() {
+      aes.encrypt(null, sampleSecurityData.aesKey);
+    }, Error );
+  });
+
+  it('should error when you try to encrypt using a null secret key value', function() {
+    assert.throws(function() {
+      aes.encrypt(null, sampleSecurityData.sessionToken);
+    }, Error );
+  });
+
+  it('should respond with ciphertext when you try to encrypt a string value', function() {
+    var encrypt = aes.encrypt(sampleSecurityData.plaintext, sampleSecurityData.sessionToken);
+    assert.equal("object", (typeof encrypt));
+  });
+
+  it('should error when you try to decrypt using a null ciphertext value', function() {
+    assert.throws(function() {
+      aes.decrypt(null, sampleSecurityData.aesKey);
+    }, Error );
+  });
+
+  it('should error when you try to decrypt using a null secret key value', function() {
+    assert.throws(function() {
+      aes.decrypt(sampleUserProfileData, null);
+    }, Error );
+  });
+
+  it('should respond with the correct plaintext when you try to decrypt some ciphertext', function() {
+    var decrypt = aes.decrypt(sampleSecurityData.sampleUserProfileDataCiphertext, sampleSecurityData.aesKey);
+    assert.equal(false, (decrypt instanceof Error), 'Should not return an error.');
+    assert.equal(JSON.stringify(sampleUserProfileData), JSON.stringify(decrypt), "It should match the specified plaintext");
+  });
+});

--- a/lib/security/sha256.js
+++ b/lib/security/sha256.js
@@ -1,0 +1,18 @@
+var CryptoJS = require("crypto-js");
+
+/**
+* Generate a SHA256 hash value for some given text.
+* @param {string} text - the text to generate a hash value.
+* @returns {string} hash
+*/
+function hash(text) {
+  if (!text) {
+    throw Error("Cannot hash Session Key - Value to hash is Null.");
+  }
+  var hash = CryptoJS.SHA256(text);
+  return hash.toString(CryptoJS.enc.Base64);
+}
+
+module.exports = {
+  hash: hash
+};

--- a/lib/user/user-client-spec.js
+++ b/lib/user/user-client-spec.js
@@ -1,0 +1,36 @@
+var assert = require('assert');
+var sinon = require('sinon');
+var userClientMock = require('../../test/mocks/user-client-mock');
+var sampleUserProfileData = require('../../test/fixtures/sampleUserProfile.json');
+var sampleSecurityData = require('../../test/fixtures/sampleSecurityData.json');
+
+describe("Test Storage/Retrieval of Profile Data", function() {
+
+  it('Should return ciphertext when the profile data and the session token are valid', function() {
+    var testEncrypt = userClientMock.storeProfile(sampleUserProfileData, sampleSecurityData.sessionToken);
+    sinon.assert.calledWith(userClientMock.storeProfile, sampleUserProfileData, sampleSecurityData.sessionToken);
+    assert.equal(false, (testEncrypt instanceof Error), 'Should not return an error.');
+  });
+
+  it('Should not attempt Encyption when the profileData is null', function() {
+    assert.throws( function() {
+      userClientMock.storeProfile(null, sampleSecurityData.sessionToken);
+    }, Error );
+    sinon.assert.calledWith(userClientMock.storeProfile, null, sampleSecurityData.sessionToken);
+  });
+
+  it('Should not attempt Encyption when the sessionToken is null', function() {
+    assert.throws( function() {
+      userClientMock.storeProfile(sampleUserProfileData, null);
+    }, Error );
+    sinon.assert.calledWith(userClientMock.storeProfile, sampleUserProfileData, null);
+  });
+
+  it('Should not attempt Encyption when both the profileData and the sessionToken are null', function() {
+    assert.throws( function() {
+      userClientMock.storeProfile(null, null);
+    }, Error );
+    sinon.assert.calledWith(userClientMock.storeProfile, null, null);
+  });
+
+});

--- a/lib/user/user-client.js
+++ b/lib/user/user-client.js
@@ -3,6 +3,8 @@
 var q = require('q');
 var _ = require('lodash');
 var config = require('./config-user');
+var aes = require('../security/aes');
+var sha256 = require('../security/sha256');
 var policyId;
 
 var UserClient = function(mediator) {
@@ -29,13 +31,43 @@ var xhr = function(_options) {
   return deferred.promise;
 };
 
-var storeProfile = function(profileData) {
-  localStorage.setItem('fh.wfm.profileData', JSON.stringify(profileData));
+/**
+* Encrypt the users profile data using AES with a hash of the session key and store the result in localStorage.
+* @param profileData {object} - the plaintext to encrypt.
+* @param sessionToken {string} - the secret key to encrypt with.
+*/
+var storeProfile = function(profileData, sessionToken) {
+  if (sessionToken && profileData) {
+
+    var hashedSessionKey = sha256.hash(sessionToken);
+    var encryptedData = aes.encrypt(profileData, hashedSessionKey);
+
+    // set the encrypted data in localStorage
+    localStorage.setItem('fh.wfm.profileData', encryptedData);
+
+  } else {
+    console.log("Session Token or Profile Data is Null. Setting profile data to null.");
+    localStorage.setItem('fh.wfm.profileData', null);
+  }
 };
 
+
+/**
+* Decrypt the users profile data using AES with a hash of the session key.
+* @returns object/null
+*/
 var retrieveProfileData = function() {
-  var json = localStorage.getItem('fh.wfm.profileData');
-  return json ? JSON.parse(json) : null;
+  var decryptedProfileData;
+  if (localStorage.getItem('fh_session_token.sessionToken') && localStorage.getItem('fh.wfm.profileData')) {
+    var ciphertext = localStorage.getItem('fh.wfm.profileData');
+    var sessionToken = JSON.parse(localStorage.getItem('fh_session_token.sessionToken')).sessionToken;
+    var hashedSessionKey = sha256.hash(sessionToken);
+    decryptedProfileData = aes.decrypt(ciphertext, hashedSessionKey);
+  } else {
+    console.log("Session Token or Profile Data is Null, Cannot Retrieve Profile Data.");
+  }
+  return decryptedProfileData;
+
 };
 
 UserClient.prototype.init = function() {
@@ -109,6 +141,7 @@ UserClient.prototype.auth = function(username, password) {
     }, function(res) {
       // res.sessionToken; // The platform session identifier
       // res.authResponse; // The authetication information returned from the authetication service.
+      var sessionToken = res.sessionToken;
       var profileData = res.authResponse;
       if (typeof profileData === 'string' || profileData instanceof String) {
         try {
@@ -119,9 +152,10 @@ UserClient.prototype.auth = function(username, password) {
           profileData = JSON.parse(profileData.replace(/,\s/g, ',').replace(/[^,={}]+/g, '"$&"').replace(/=/g, ':'));
         }
       }
-      storeProfile(profileData);
+      storeProfile(profileData, sessionToken);
       self.mediator.publish('wfm:auth:profile:change', profileData);
       deferred.resolve(res);
+
     }, function(msg, err) {
       console.log(msg, err);
       var errorMsg = err.message;
@@ -171,12 +205,12 @@ UserClient.prototype.clearSession = function() {
       console.log('Failed to clear session: ', err);
       deferred.reject(err);
     } else {
-      storeProfile(null);
       self.mediator.publish('wfm:auth:profile:change', null);
+      localStorage.clear();
       deferred.resolve(true);
     }
+    return deferred.promise;
   });
-  return deferred.promise;
 };
 
 UserClient.prototype.verify = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A user module for WFM",
   "main": "lib/angular/user-ng.js",
   "repository": {
@@ -21,6 +21,7 @@
   "dependencies": {
     "connect-mongo": "^1.3.2",
     "connect-redis": "^3.1.0",
+    "crypto-js": "3.1.8",
     "express": "4.14.0",
     "express-session": "^1.14.2",
     "fh-mbaas-api": "5.14.2",

--- a/test/fixtures/sampleSecurityData.json
+++ b/test/fixtures/sampleSecurityData.json
@@ -1,0 +1,8 @@
+{
+  "sessionToken": "secret_token",
+  "plaintext": "plaintext",
+  "plaintextSha256": "ltYuKr0+Qt5fUDMPuO/ExVmYNSeAd7IemqCzPB3wehw=",
+  "aesKey":"secret",
+  "ciphertextLength": 556,
+  "sampleUserProfileDataCiphertext": "U2FsdGVkX19wiZrKkC+r+4BvhuhJq0LuNd0lLOBtFOShIgtmy0SFrZQBYNeDkuMvYUna1NalSzXbqxAYmWUPMPELXWf71MzLvBlFrLnviCya759l7bfPUAqaW0lUexLQOJLU6x3CvVGWPzHlZkYkTBmmx0Du6tIaFdKYs6kBeMNXjCmcSvpyzmTxxSqB1DtoVk08/gz/cWdse+AuXCp8YnRZFkvPa4v3dF+oqX3RvHI/CJgbqZ6sP1mzRmkYF7wbuUhJjhaaksrrd46Gh6pYai+AqN8c0gaAzb3flfL1Sw0KWQDDMaK0VQwRZhCD6SyRXa6ChBKMdw9LMo8iSFXYXl7vtNE6cmU5Ol4Uy6EXdBud32U7jDgTo6v+meG8x1rdIHqrND8tXa5Sjl8xaZt310vJBIKm08usiSdKcgcJOSYaDqQtZLG2klwWdMEFfKcdBn4FN4kS5MYPBrPjt0qHedvVyCa1Pvm95tGUN5U/kvU2gJBqbEPnn9UJJ49D568O9tNVRpbRNB3xCzPRcDtQcOTlRzuHoM0sumCCqjh5j6k="
+}

--- a/test/mocks/user-client-mock.js
+++ b/test/mocks/user-client-mock.js
@@ -1,0 +1,38 @@
+var sinon = require('sinon');
+var sampleSecurityData = require('../fixtures/sampleSecurityData.json');
+
+/**
+* Simple function to mock the logic for profile data encryption without using phantom/jsdom to mock localstorage interactions.
+* The tests for the underlying security functionality is found in lib/security
+* @param {object} profileData - the users profile data
+* @param {string} sessionToken - the users sessionToken
+*/
+function storeProfile() {
+  var stub = sinon.stub();
+
+  // valid data case
+  stub.withArgs(
+  sinon.match(sinon.match.typeOf("object")),
+  sinon.match(sinon.match.string)).returns(sampleSecurityData.sampleUserProfileDataCiphertext);
+
+  // invalid profileData case
+  stub.withArgs(
+  sinon.match(sinon.match.typeOf("null")),
+  sinon.match(sinon.match.string)).throws(Error("Session Token or Profile Data is Null. Setting profile data to null."));
+
+  // invalid sessionToken case
+  stub.withArgs(
+  sinon.match(sinon.match.object),
+  sinon.match(sinon.match.typeOf("null"))).throws(Error("Session Token or Profile Data is Null. Setting profile data to null."));
+
+  // invalid profileData and sessionToken case
+  stub.withArgs(
+  sinon.match(sinon.match.typeOf("null")),
+  sinon.match(sinon.match.typeOf("null"))).throws(Error("Session Token or Profile Data is Null. Setting profile data to null."));
+
+  return stub;
+}
+
+module.exports = {
+  storeProfile: storeProfile()
+};


### PR DESCRIPTION
**Motivation**
Sensitive worker information (eg. messages, email addresses) are being stored in plaintext format in localstorage on a device. This information can be extracted from a device very easily. Recoverable under `/data/data/com.app.name` in Android. 

The Profile Data is being encrypted using AES-256 in CBC mode with the secret key being a SHA256 of the users current session key when they login. The profile data is wiped when the user logs out. The security functionality is broken out into separate files under /security so it can be reused again for other uses in the future. If the session key or profile data returned in the auth response is null, the profileData will be set to null in localstorage, as before.

The users messages which come from sync are not being encypted as part of this change as Sync is handling the storage/retrieval of the messages itself and can't be changed from raincatcher-user. Similarly, the session token is not being encrypted as this will be stored in a cookie in the future.

**JIRA Ticket**
https://issues.jboss.org/browse/RAINCATCH-409