### PR TITLE
disables auto-complete on password form fields

### DIFF
--- a/dist/worker-form.tpl.html.js
+++ b/dist/worker-form.tpl.html.js
@@ -45,7 +45,7 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '\n' +
     '  <md-input-container class="md-block">\n' +
     '    <label for="password">Password</label>\n' +
-    '    <input type="password" id="password" name="password" ng-model="ctrl.model.password">\n' +
+    '    <input type="password" id="password" name="password" ng-model="ctrl.model.password" autocomplete="off">\n' +
     '    <div ng-messages="workerForm.password.$error" ng-if="ctrl.submitted || workerForm.password.$dirty">\n' +
     '    </div>\n' +
     '  </md-input-container>\n' +

--- a/lib/angular/template/worker-form.tpl.html
+++ b/lib/angular/template/worker-form.tpl.html
@@ -36,7 +36,7 @@
 
   <md-input-container class="md-block">
     <label for="password">Password</label>
-    <input type="password" id="password" name="password" ng-model="ctrl.model.password">
+    <input type="password" id="password" name="password" ng-model="ctrl.model.password" autocomplete="off">
     <div ng-messages="workerForm.password.$error" ng-if="ctrl.submitted || workerForm.password.$dirty">
     </div>
   </md-input-container>


### PR DESCRIPTION
Disables the auto-completion of the password field in raincatcher-user by specifying autocomplete="off" on the password field in the login view

Part of the JIRA: https://issues.jboss.org/browse/RAINCATCH-407
(rest of JIRA is to do the same for raincatcher-demo-mobile & raincatcher-demo-portal)

@TommyJ1994 @witmicko can you take a look if you get a chance & see if ok