### PR TITLE
Fix missing error handling for cache

### DIFF
--- a/lib/middleware/sessionCache.js
+++ b/lib/middleware/sessionCache.js
@@ -12,8 +12,11 @@ function checkSession(mbaasApi, sessionToken, cb) {
     "act": "load",
     "key": sessionToken
   };
-
-  mbaasApi.cache(options, function(err, session) {
+  
+  mbaasApi.cache(options, function(err, session){
+    if(err){
+      return cb(err);
+    }
     return cb(err, JSON.parse(session));
   });
 }


### PR DESCRIPTION
# Motivation

Missing error handler crashing component when cache is out memory. 
This fix would prevent from that.

ping @some-raincacher-team-members ? 