### PR TITLE
Add Missing Create User Param in MBaaS Router

### DIFF
--- a/lib/router/mbaas.js
+++ b/lib/router/mbaas.js
@@ -91,7 +91,7 @@ function initRouter(mediator, authResponseExclusionList, expressSessionMiddlewar
     mediator.once('done:wfm:user:create:' + ts, function(createduser) {
       res.json(createduser);
     });
-    mediator.publish('wfm:user:create', user);
+    mediator.publish('wfm:user:create', user, ts);
   });
   router.route('/:id').delete(function(req, res) {
     var userId = req.params.id;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A user module for WFM",
   "main": "lib/angular/user-ng.js",
   "repository": {


### PR DESCRIPTION
Fix for an issue that occurs when trying to create a user, which causes the UI to hang. The issue is that the timestamp variable is not being passed as part of the mediator publish.

[Jira Ticket](https://issues.jboss.org/browse/RAINCATCH-542)