### PR TITLE
remove travis nsp checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ services:
 sudo: false
 before_install:
   - npm install -g npm@2.13.5
-  - npm install -g nsp
 install: npm install
 script:
   - npm test
-  - nsp check; exit 0
   - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false

--- a/lib/middleware/sessionCache.js
+++ b/lib/middleware/sessionCache.js
@@ -12,9 +12,9 @@ function checkSession(mbaasApi, sessionToken, cb) {
     "act": "load",
     "key": sessionToken
   };
-  
-  mbaasApi.cache(options, function(err, session){
-    if(err){
+
+  mbaasApi.cache(options, function(err, session) {
+    if (err) {
       return cb(err);
     }
     return cb(err, JSON.parse(session));

--- a/lib/router/mbaas-session-middleware-spec.js
+++ b/lib/router/mbaas-session-middleware-spec.js
@@ -1,16 +1,16 @@
 'use strict';
-const assert = require('assert');
-const proxyquire = require('proxyquire');
-const sinon = require('sinon');
+var assert = require('assert');
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
 
 // setup proxies for module under test
-const mongoProviderProxy = {
+var mongoProviderProxy = {
   init: sinon.stub().callsArg(2)
 };
-const redisProviderProxy = {
+var redisProviderProxy = {
   init: sinon.stub().callsArg(2)
 };
-const mbaasSessionMiddleware = proxyquire('./mbaas-session-middleware', {
+var mbaasSessionMiddleware = proxyquire('./mbaas-session-middleware', {
   '../session/mongoProvider': mongoProviderProxy,
   '../session/redisProvider': redisProviderProxy
 });


### PR DESCRIPTION
**Motivation**
NSP was obsoleted by using snyk for checking vulnerabilities in dependencies. Currently the hack done for it to be an 'optional' check i.e. not fail builds is actually making CI builds that are supposed to fail pass.

- fix eslint errors
- fix failing node 0.10 errors due to use of const in strict mode