### PR TITLE
Remove NSP checks from Travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "build": "wfm-template-build -m 'wfm.user.directives'",
     "watch": "wfm-template-build -w -m 'wfm.user.directives'",
-    "vuln": "nsp check",
     "test": "WFM_USE_MEMORY_STORE=true grunt"
   },
   "keywords": [
@@ -48,7 +47,6 @@
     "grunt-shell": "1.2.1",
     "load-grunt-tasks": "^3.5.2",
     "mocha": "^3.2.0",
-    "nsp": "^2.6.2",
     "proxyquire": "^1.7.10",
     "sinon": "^1.17.6",
     "sinon-as-promised": "^4.0.2",


### PR DESCRIPTION
- These are no longer necessary as Snyk is being used for security checks on PR's.