### PR TITLE
Added user mediator topics

### DIFF
--- a/lib/client/mediator-topics/index.js
+++ b/lib/client/mediator-topics/index.js
@@ -1,7 +1,8 @@
 var _ = require('lodash');
 var topicHandlers = {
   list: require('./list'),
-  read: require('./read')
+  read: require('./read'),
+  read_profile: require('./read_profile')
 };
 var CONSTANTS = require('../../constants');
 

--- a/lib/client/mediator-topics/read_profile-spec.js
+++ b/lib/client/mediator-topics/read_profile-spec.js
@@ -1,0 +1,106 @@
+var CONSTANTS = require('../../constants');
+var sinon = require('sinon');
+require('sinon-as-promised');
+var chai = require('chai');
+var _ = require('lodash');
+var expect = chai.expect;
+
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var mockUser = require('../../../test/fixtures/sampleUserProfile.json');
+
+
+
+describe("Reading Currently Logged In User", function() {
+
+  var usersReadProfileTopic = "wfm:users:read_profile";
+
+  var userSubscribers = new MediatorTopicUtility(mediator);
+  userSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.USER_ENTITY_NAME);
+
+  function getMockReadUsers(returnError) {
+    var userStub = sinon.stub();
+
+    return {
+      getProfile: returnError ? userStub.rejects(new Error("Error reading user profile")) : userStub.resolves(mockUser)
+    };
+  }
+
+
+  function createReadSubscriber(mockUserClient) {
+    userSubscribers.on(CONSTANTS.TOPICS.READ_PROFILE, require('./read_profile')(userSubscribers, mockUserClient));
+  }
+
+
+  beforeEach(function() {
+    this.subscribers = {};
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    userSubscribers.unsubscribeAll();
+  });
+
+  it("should read a user profile", function() {
+
+    var mockUserClient = getMockReadUsers(false);
+
+    createReadSubscriber(mockUserClient);
+
+    var doneReadUsersTopic = "done:wfm:users:read_profile";
+
+    var readUsersPromise = mediator.promise(doneReadUsersTopic);
+
+    mediator.publish(usersReadProfileTopic, {
+      id: mockUser.id
+    });
+
+    return readUsersPromise.then(function(user) {
+      expect(user).to.deep.equal(mockUser);
+      sinon.assert.calledOnce(mockUserClient.getProfile);
+    });
+  });
+
+  it("should read a user and respond to a unique topic id", function() {
+
+    var mockUserClient = getMockReadUsers(false);
+
+    createReadSubscriber(mockUserClient);
+
+    var doneReadUsersTopic = "done:wfm:users:read_profile:" +mockUser.id;
+
+    var readUsersPromise = mediator.promise(doneReadUsersTopic);
+
+    mediator.publish(usersReadProfileTopic, {
+      id: mockUser.id,
+      topicUid: mockUser.id
+    });
+
+    return readUsersPromise.then(function(user) {
+      expect(user).to.deep.equal(mockUser);
+      sinon.assert.calledOnce(mockUserClient.getProfile);
+    });
+  });
+
+  it("should publish an error if there is an error reading users", function() {
+    var mockUserClient = getMockReadUsers(true);
+
+    createReadSubscriber(mockUserClient);
+
+    var errorReadUserTopic = "error:wfm:users:read_profile";
+
+    var readUsersErrorPromise = mediator.promise(errorReadUserTopic);
+
+    mediator.publish(usersReadProfileTopic);
+
+    return readUsersErrorPromise.then(function(error) {
+      expect(error.message).to.contain("profile");
+      sinon.assert.calledOnce(mockUserClient.getProfile);
+    });
+  });
+
+});
+

--- a/lib/client/mediator-topics/read_profile.js
+++ b/lib/client/mediator-topics/read_profile.js
@@ -1,0 +1,32 @@
+var CONSTANTS = require('../../constants');
+
+/**
+ * Initialsing a subscriber for Reading users.
+ *
+ * @param {object} userEntityTopics
+ * @param {UserClient} userClient - The User Client
+ */
+module.exports = function readCurrentLoggedInUser(userEntityTopics, userClient) {
+
+  /**
+   *
+   * Handling the reading of the current logged in user.
+   *
+   * @param {object} parameters
+   * @param {string/number} parameters.topicUid  - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleReadCurrentLoggedInUser(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var readProfileDoneTopic = userEntityTopics.getTopic(CONSTANTS.TOPICS.READ_PROFILE, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+    var readProfileErrorTopic = userEntityTopics.getTopic(CONSTANTS.TOPICS.READ_PROFILE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    userClient.getProfile()
+      .then(function(userProfile) {
+        self.mediator.publish(readProfileDoneTopic, userProfile);
+      }).catch(function(error) {
+        self.mediator.publish(readProfileErrorTopic, error);
+      });
+  };
+};

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,6 +5,7 @@ module.exports = {
   DONE_PREFIX: "done",
   TOPICS: {
     LIST: "list",
-    READ: "read"
+    READ: "read",
+    READ_PROFILE: "read_profile"
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A user module for WFM",
   "main": "lib/angular/user-ng.js",
   "repository": {


### PR DESCRIPTION
# Motivation 

This is related to the refactoring of the raincatcher-workflow and raincatcher-workorder modules.

These modules need the following topics available to be able to work correctly:
- wfm:users:read_profile - Reading the currently logged in user.