### PR TITLE
[RAINCATCH-624] Generate user id and use it as topic identifier

### DIFF
--- a/lib/router/mbaas.js
+++ b/lib/router/mbaas.js
@@ -4,6 +4,7 @@ var express = require('express');
 var config = require('../user/config-user');
 var userAuth = require('./mbaas-auth');
 var sessionMiddleware = require('./mbaas-session-middleware');
+var shortid = require('shortid');
 var _ = require('lodash');
 
 function initRouter(mediator, authResponseExclusionList, expressSessionMiddleware) {
@@ -84,13 +85,16 @@ function initRouter(mediator, authResponseExclusionList, expressSessionMiddlewar
     mediator.publish('wfm:user:update', user);
   });
   router.route('/').post(function(req, res) {
-    var ts = new Date().getTime();  // TODO: replace this with a proper uniqe (eg. a cuid)
+    var ts = new Date().getTime();
     var user = req.body.user;
     user.createdTs = ts;
-    mediator.once('done:wfm:user:create:' + ts, function(createduser) {
+    if (!user.id) {
+      user.id = shortid.generate();
+    }
+    mediator.once('done:wfm:user:create:' + user.id, function(createduser) {
       res.json(createduser);
     });
-    mediator.publish('wfm:user:create', user, ts);
+    mediator.publish('wfm:user:create', user);
   });
   router.route('/:id').delete(function(req, res) {
     var userId = req.params.id;


### PR DESCRIPTION
Bug's cause was using the timestamp with the new store based on fh-wfm-simple-store, which picks up `user.id` instead.

Generating an id beforehand will make the return topic be properly answered and it'll bubble back to the web UI as before. Same thing was done for memberships and groups.

ping @grdryn @JameelB @TommyJ1994 