### PR TITLE
⬆ Upgrade to fh-mbaas-api@6.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "crypto-js": "3.1.8",
     "express": "4.14.0",
     "express-session": "^1.14.2",
-    "fh-mbaas-api": "6.1.6",
+    "fh-mbaas-api": "6.1.7",
     "fh-wfm-mediator": "0.3.1",
     "fh-wfm-simple-store": "0.1.2",
     "lodash": "4.7.0",


### PR DESCRIPTION
The demo cloud app already has 6.1.7 (kind of...it's not really shrinkwrapped properly I think), so this should also.