### PR TITLE
[Raincatch-513] Prevent Password Return on User Read (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In the MBaaS service that authenticates users (e.g. [raincatcher-demo-auth](http
 
 See the [Setup router for Cloud App](#setup-router-for-cloud-app) section for more details.
 
-Version 0.2.1 introduced encryption of the users profile data in localstorage (fh.wfm.profileData). The user will likely need to clear the app data/cache in their phones system settings for this feature to work, as previous plaintext profile data may be left on the phone causing an error when trying to decrypt it. To clear the app data on Android: 
+Version 0.2.1 introduced encryption of the users profile data in localstorage (fh.wfm.profileData). The user will likely need to clear the app data/cache in their phones system settings for this feature to work, as previous plaintext profile data may be left on the phone causing an error when trying to decrypt it. To clear the app data on Android:
 
 * Step 1: Head to the Settings menu. This can be done by tapping the cog icon in your notification shade.
 * Step 2: Find Apps (or Applications, depending on your device) in the menu, then locate the app that you want to clear the cache or data for.
@@ -140,7 +140,7 @@ const userRouter = require('fh-wfm-user/lib/router/mbaas');
 userRouter.init(
   mediator, // fh-wfm-mediator instance
   expressApp, // express application upon which to mount the router
-  ['password'], // list of fields from Users to exclude from the HTTP responses
+  ['password'], // userProfileExclusionList - the list of fields from a Users profile to exclude from the HTTP responses
 
   // Session storage configuration, new in 0.2.0
   {
@@ -169,7 +169,7 @@ userRouter.init(
   });
 ```
 
-Note: Setting the `authResponseExclusionList` array as `['password', 'banner']` will prevent these fields from appearing in the authentication response. By default, the `password` field is removed from the response. To allow all fields to be sent, set `authResponseExclusionList` to an empty array.
+Note: Setting the `userProfileExclusionList` array as `['password', 'banner']` will prevent these fields from appearing in the authentication response. By default, the `password` field is removed from the response. To allow all fields to be sent, set `userProfileExclusionList` to an empty array.
 
 For a more complete example check [the example initialization on raincatcher-demo-auth](https://github.com/feedhenry-raincatcher/raincatcher-demo-auth/blob/0e9d5edb200fdf84e39ce4dac08c48fadefded8a/application.js#L61).
 

--- a/lib/router/mbaas-spec.js
+++ b/lib/router/mbaas-spec.js
@@ -95,13 +95,13 @@ describe('Test mbass authentication', function() {
 
 describe('#testAuthResponseData', function() {
   it('it should not remove any fields when an empty exclusion list is specified', function(done) {
-    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList3);
+    var authResponse = authHandler.trimProfileData(_.clone(sampleProfileData), sampleExclusionList3);
     assert(Object.keys(authResponse).length === sampleProfileDataLength,
       "Expect that specifying an empty exclusion list returns all the User fields in the response.");
     done();
   });
   it('it should remove the password field by default', function(done) {
-    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleUserConfig.authResponseExclusionList);
+    var authResponse = authHandler.trimProfileData(_.clone(sampleProfileData), sampleUserConfig.authResponseExclusionList);
     assert(authResponse.password === undefined,
       "Check that the Password field has been removed from the Response.");
     assert(Object.keys(authResponse).length !== sampleProfileDataLength,
@@ -109,7 +109,7 @@ describe('#testAuthResponseData', function() {
     done();
   });
   it('it should remove a single field when specified', function(done) {
-    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList1);
+    var authResponse = authHandler.trimProfileData(_.clone(sampleProfileData), sampleExclusionList1);
     assert(authResponse.banner === undefined,
       "Check that the Banner field has been removed from the Response.");
     assert(Object.keys(authResponse).length !== sampleProfileDataLength,
@@ -117,7 +117,7 @@ describe('#testAuthResponseData', function() {
     done();
   });
   it('it should remove a single field when specified and also not remove the password', function(done) {
-    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList1);
+    var authResponse = authHandler.trimProfileData(_.clone(sampleProfileData), sampleExclusionList1);
     assert(authResponse.banner === undefined,
       "Check that the Banner field has been removed from the Response.");
     assert(authResponse.password !== undefined,
@@ -127,7 +127,7 @@ describe('#testAuthResponseData', function() {
     done();
   });
   it('it should remove a number of fields when specified', function(done) {
-    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList2);
+    var authResponse = authHandler.trimProfileData(_.clone(sampleProfileData), sampleExclusionList2);
     assert(authResponse.banner === undefined,
       "Check that the Banner field has been removed from the Response.");
     assert(authResponse.avatar === undefined,
@@ -137,7 +137,7 @@ describe('#testAuthResponseData', function() {
     done();
   });
   it('it should remove the password field by default when the exclusion list is undefined', function(done) {
-    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList4);
+    var authResponse = authHandler.trimProfileData(_.clone(sampleProfileData), sampleExclusionList4);
     assert(authResponse.password === undefined,
       "Check that the Password field has been removed from the Response.");
     assert(Object.keys(authResponse).length !== sampleProfileDataLength,
@@ -145,7 +145,7 @@ describe('#testAuthResponseData', function() {
     done();
   });
   it('it should remove the password field by default when the exclusion list is null', function(done) {
-    var authResponse = authHandler.trimAuthResponse(_.clone(sampleProfileData), sampleExclusionList5);
+    var authResponse = authHandler.trimProfileData(_.clone(sampleProfileData), sampleExclusionList5);
     assert(authResponse.password === undefined,
       "Check that the Password field has been removed from the Response.");
     assert(Object.keys(authResponse).length !== sampleProfileDataLength,

--- a/lib/router/mbaas.js
+++ b/lib/router/mbaas.js
@@ -7,7 +7,7 @@ var sessionMiddleware = require('./mbaas-session-middleware');
 var shortid = require('shortid');
 var _ = require('lodash');
 
-function initRouter(mediator, authResponseExclusionList, expressSessionMiddleware) {
+function initRouter(mediator, userProfileExclusionList, expressSessionMiddleware) {
   var router = express.Router();
 
   router.all('/auth', function(req, res) {
@@ -24,8 +24,8 @@ function initRouter(mediator, authResponseExclusionList, expressSessionMiddlewar
     // try to authenticate
     userAuth.auth(mediator, userId, params.password)
       .then(function(profileData) {
-        // trim the authentication response to remove specified fields
-        var authResponse = trimAuthResponse(profileData, authResponseExclusionList);
+        // trim the user profile data to remove specified fields when a user read from the database occurs
+        var authResponse = trimProfileData(profileData, userProfileExclusionList);
         // on success pass relevant data into response
 
         //Using express-session to generate and store a session.
@@ -65,13 +65,19 @@ function initRouter(mediator, authResponseExclusionList, expressSessionMiddlewar
 
   router.route('/').get(function(req, res) {
     mediator.once('done:wfm:user:list', function(data) {
+      // remove any sensitive fields from the user profile data, eg password.
+      _.forEach(data, function(user, index) {
+        data[index] = trimProfileData(user, userProfileExclusionList);
+      });
       res.json(data);
     });
     mediator.publish('wfm:user:list');
   });
   router.route('/:id').get(function(req, res) {
     var userId = req.params.id;
+    // remove any sensitive fields from the user profile data, eg password.
     mediator.once('done:wfm:user:read:' + userId, function(data) {
+      data = trimProfileData(data, userProfileExclusionList);
       res.json(data);
     });
     mediator.publish('wfm:user:read', userId);
@@ -108,18 +114,18 @@ function initRouter(mediator, authResponseExclusionList, expressSessionMiddlewar
 }
 
 /**
-* Function to trim the authentication response to remove certain fields from being sent.
+* Function to trim the User Profile Data to prevent sensitive fields from being sent.
 * By default, the password will be removed from the response.
-* @param authResponse {object} - the untrimmed auth response
+* @param profileData {object} - the untrimmed user profile data
 * @param exclusionList {array} - the array of field names to remove from the authentication response
-* @return authResponse {object} - the trimmed authentication response
+* @return trimmedProfileData {object} - the trimmed profileData
 */
-function trimAuthResponse(authResponse, exclusionList) {
-  if (exclusionList === undefined || exclusionList === null) {
+function trimProfileData(profileData, exclusionList) {
+  if (!exclusionList) {
     // return a default auth response if the exclusion list is null or undefined
-    return _.omit(authResponse, config.defaultAuthResponseExclusionList);
+    return _.omit(profileData, config.defaultProfileDataExclusionList);
   }
-  return _.omit(authResponse, exclusionList);
+  return _.omit(profileData, exclusionList);
 }
 
 /**
@@ -155,5 +161,5 @@ function init(mediator, app, authResponseExclusionList, sessionOptions, cb) {
 
 module.exports = {
   init: init,
-  trimAuthResponse: trimAuthResponse
+  trimProfileData: trimProfileData
 };

--- a/lib/user/config-user.js
+++ b/lib/user/config-user.js
@@ -5,6 +5,6 @@ module.exports = {
   apiPath: '/api/wfm/user',
   authpolicyPath: '/box/srv/1.1/admin/authpolicy',
   policyId: process.env.WFM_AUTH_POLICY_ID || 'wfm',
-  defaultAuthResponseExclusionList: ['password'],
+  defaultProfileDataExclusionList: ['password'],
   sessionTokenExpiry: 1800
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A user module for WFM",
   "main": "lib/angular/user-ng.js",
   "repository": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.host.url=https://sonarqube.com
 sonar.projectKey=raincatcher-user
 sonar.projectName=raincatcher-user
-sonar.projectVersion=0.5.3
+sonar.projectVersion=0.5.4
 
 sonar.sources=./lib
 sonar.language=js


### PR DESCRIPTION
**Motivation**

- The full user profile data is being returned on a User Read/User List in the receiver object for a message in the mobile client and portal app. 
- This is also being stored in a plaintext object on the mobile device. 
- This is also recoverable from the Portal UI when you edit a worker.

1. The changes prevent the users password being sent on a user read by default.
2. Updated the  The developer can also choose which fields to also remove in array format eg. `['password', 'email']` - this can be set in raincatcher-demo-auth/application.js
3. The password field in the Portal UI is now blank when you try and edit a worker - before it was the SHA-1 of the password.


