### PR TITLE
Raincatch 657 fix login bypass

### DIFF
--- a/lib/client/user/user-client-spec.js
+++ b/lib/client/user/user-client-spec.js
@@ -1,8 +1,12 @@
 var assert = require('assert');
 var sinon = require('sinon');
+var chai = require('chai');
 var userClientMock = require('../../../test/mocks/user-client-mock');
 var sampleUserProfileData = require('../../../test/fixtures/sampleUserProfile.json');
 var sampleSecurityData = require('../../../test/fixtures/sampleSecurityData.json');
+
+var UserClient = require('./user-client');
+var mediator = require('fh-wfm-mediator/lib/mediator');
 
 describe("Test Storage/Retrieval of Profile Data", function() {
 
@@ -31,6 +35,60 @@ describe("Test Storage/Retrieval of Profile Data", function() {
       userClientMock.storeProfile(null, null);
     }, Error );
     sinon.assert.calledWith(userClientMock.storeProfile, null, null);
+  });
+
+});
+
+
+describe("Test Cacheing Authentication Responses", function() {
+
+
+  var userClient;
+  var cloudStub = sinon.stub().callsArg(1);
+  var fhInitStub = sinon.stub().callsArg(1);
+
+  var getFHParamsStub = sinon.stub().returns({appId: "someappid"});
+
+  before(function() {
+
+    $fh = {
+      cloud: cloudStub,
+      on: fhInitStub,
+      getFHParams: getFHParamsStub
+    };
+
+    localStorage = {
+      setItem: sinon.stub(),
+      clear: sinon.stub()
+    };
+
+    userClient = UserClient(mediator);
+  });
+
+  it("should cache an authenticated session", function() {
+
+    var authStub = sinon.stub().callsArgWith(1, {sessionToken: "somesessiontoken", authResponse: sampleUserProfileData});
+
+    $fh.auth = authStub;
+
+    chai.expect(userClient.userVerified).to.equal(false);
+
+    return userClient.auth("someusername", "somepassword").then(function() {
+      sinon.assert.calledOnce(authStub);
+      chai.expect(userClient.userVerified).to.equal(true);
+    });
+  });
+
+  it("should reset the cached verified when the session is cleared", function() {
+
+    $fh.auth = {
+      clearSession: sinon.stub().callsArg(0)
+    };
+
+    return userClient.clearSession().then(function() {
+      sinon.assert.calledOnce($fh.auth.clearSession);
+      chai.expect(userClient.userVerified).to.equal(false);
+    });
   });
 
 });

--- a/lib/client/user/user-client.js
+++ b/lib/client/user/user-client.js
@@ -13,6 +13,9 @@ var UserClient = function(mediator) {
   this.mediator = mediator;
   this.initComplete = false;
   this.initPromise = this.init();
+
+  //Flag to cache user verification.
+  this.userVerified = false;
 };
 
 var xhr = function(_options) {
@@ -128,6 +131,10 @@ UserClient.prototype.create = function(user) {
 UserClient.prototype.auth = function(username, password) {
   var deferred = q.defer();
   var self = this;
+
+  //There is an attempted login, marking the userVerified flag as false in case the verification fails.
+  self.userVerified = false;
+
   this.initPromise.then(function() {
     $fh.auth({
       policyId: policyId,
@@ -150,6 +157,8 @@ UserClient.prototype.auth = function(username, password) {
         }
       }
       storeProfile(profileData, sessionToken);
+      //Authentication was successful, mark the userVerified flag as true.
+      self.userVerified = true;
       self.mediator.publish('wfm:auth:profile:change', profileData);
       deferred.resolve(res);
 
@@ -190,6 +199,8 @@ UserClient.prototype.hasSession = function() {
 UserClient.prototype.clearSession = function() {
   var deferred = q.defer();
   var self = this;
+
+  self.userVerified = false;
   $fh.auth.clearSession(function(err) {
     if (err) {
       console.log('Failed to clear session: ', err);
@@ -205,13 +216,22 @@ UserClient.prototype.clearSession = function() {
 };
 
 UserClient.prototype.verify = function() {
+  var self = this;
+
+  //If the user has already been verified, then no need to do it again.
+  if (this.userVerified) {
+    return q.when(true);
+  }
+
   var deferred = q.defer();
+
   $fh.auth.verify(function(err, valid) {
     if (err) {
       console.log('failed to verify session');
       deferred.reject(new Error(err));
       return;
     } else if (valid) {
+      self.userVerified = true;
       deferred.resolve(true);
     } else {
       deferred.resolve(false);

--- a/lib/client/user/user-client.js
+++ b/lib/client/user/user-client.js
@@ -74,6 +74,7 @@ var retrieveProfileData = function() {
 UserClient.prototype.init = function() {
   var deferred = q.defer();
   var self = this;
+
   $fh.on('fhinit', function(error) {
     if (error) {
       deferred.reject(new Error(error));
@@ -156,6 +157,7 @@ UserClient.prototype.auth = function(username, password) {
           profileData = JSON.parse(profileData.replace(/,\s/g, ',').replace(/[^,={}]+/g, '"$&"').replace(/=/g, ':'));
         }
       }
+
       storeProfile(profileData, sessionToken);
       //Authentication was successful, mark the userVerified flag as true.
       self.userVerified = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A user module for WFM",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Motivation

It should be the responsibility of the core module to verify that the currently logged in used has a valid session.

# Changes

Added a `userVerified` property to the `UserClient` to cache if the currently logged in user has a valid session.