### PR TITLE
[RAINCATCH-796] display error messages correctly when authenticating user

### DIFF
--- a/lib/client/user/user-client.js
+++ b/lib/client/user/user-client.js
@@ -165,7 +165,6 @@ UserClient.prototype.auth = function(username, password) {
       deferred.resolve(res);
 
     }, function(code, errorMsg) {
-
       /* Possible errors:
       unknown_policyId - The policyId provided did not match any defined policy. Check the Auth Policies defined. See Auth Policies Administration
       user_not_found - The Auth Policy associated with the policyId provided has been set up to require that all users authenticating exist on the platform, but this user does not exists.
@@ -175,7 +174,11 @@ UserClient.prototype.auth = function(username, password) {
       device_disabled - The device has been disabled. No user or apps can log in from the requesting device.
       device_purge_data - The device has been flagged for data purge and all local data should be deleted.
       */
-      deferred.reject(new Error(errorMsg));
+      if (typeof errorMsg === 'object') {
+        deferred.reject(new Error(code)); //for errors other than the given errors above. i.e. internal errors
+      } else {
+        deferred.reject(new Error(errorMsg));
+      }
     });
   });
   return deferred.promise;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A user module for WFM",
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
     "express": "4.15.2",
     "express-session": "^1.14.2",
     "fh-mbaas-api": "6.1.8",
-    "fh-wfm-mediator": "0.3.3",
+    "fh-wfm-mediator": "0.3.4",
     "fh-wfm-simple-store": "0.2.3",
     "lodash": "4.17.4",
     "mongodb": "^2.2.16",


### PR DESCRIPTION
# What
When authenticating a user, internal error messages are shown as `Error: [object Object]` in the portal and mobile app. The auth in user client does not accommodate for other errors other than what's given by $fh.auth. In such cases, the error message is given in the first parameter of the function and the second parameter `errorMsg` is an object with the following properties: `{status: 500, error: '', msg: 'error'}`

# JIRA Ticket
https://issues.jboss.org/browse/RAINCATCH-796