### PR TITLE
RAINCATCH-805 - New api for retrieving user for session token

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ app.use('mbaas/sync', validateSession(mediator, mbaasApi,
 ));
 ```
 
+
+### Retrieving user id for session
+
+Top level applications can now obtain userId for sessionToken.
+Instead of sending user id from client, current logged user id can be now obtained from session token.
+See example bellow:
+
+```javascript
+var mbaasApi = require('fh-mbaas-api');
+var userSessionApi = require("fh-wfm-user/lib/cloud/sessionApi")(mbaasApi);
+  
+return userSessionApi.getUserIdForSessionPromise(filter.sessionToken).then(function(userId){
+  console.log("userId", userId);
+});
+```
+
 ### Setup MBaaS authentication service
 
 ```javascript

--- a/lib/cloud/middleware/verifySession.js
+++ b/lib/cloud/middleware/verifySession.js
@@ -18,13 +18,11 @@ module.exports = function verifySession(mediator, mbaasApi, sessionToken, sessio
         return cb();
       }
 
-      sessionCache.saveSession(mbaasApi, sessionToken, session, function(err, sessionSaved) {
+      sessionCache.saveSession(mbaasApi, sessionToken, verifiedSession, function(err, sessionSaved) {
         if (err) {
           return cb(err);
         }
-
         return cb(undefined, sessionSaved);
-
       });
 
     }, function(err) {

--- a/lib/cloud/sessionApi.js
+++ b/lib/cloud/sessionApi.js
@@ -1,0 +1,36 @@
+var sessionCache = require("./middleware/sessionCache");
+var Promise = require("bluebird");
+var sessionApi = {};
+
+/**
+ * Api for user cache management
+ *
+ * @param clientMbaasApi
+ * @returns {Object} api object
+ */
+module.exports = function(clientMbaasApi) {
+  sessionApi.mbaasApi = clientMbaasApi;
+  return sessionApi;
+};
+
+/**
+ * Retrieves ID of current logged user
+ *
+ * @param {string} sessionToken session token of the logged user
+ */
+sessionApi.getUserIdForSession = function(sessionToken) {
+  return new Promise(function(resolve, reject) {
+    sessionCache.checkSession(sessionApi.mbaasApi, sessionToken, function(err, cachedObj) {
+      if (err) {
+        return reject(err);
+      }
+      if (cachedObj && cachedObj.session) {
+        var session = JSON.parse(cachedObj.session);
+        return resolve(session.userId);
+      }
+      reject(new Error("No session"));
+    });
+  });
+};
+
+

--- a/lib/mbaas/index.js
+++ b/lib/mbaas/index.js
@@ -35,7 +35,7 @@ function initRouter(mediator, userProfileExclusionList, expressSessionMiddleware
           if (err) {
             return res.status(500).json({message: "Unexpected error when creating a session. Please try again."});
           }
-
+          req.session.userId = profileData.id;
           return res.status(200).json({
             status: 'ok',
             userId: userId,
@@ -53,9 +53,7 @@ function initRouter(mediator, userProfileExclusionList, expressSessionMiddleware
   });
 
   router.all('/verifysession', sessionMiddleware.verifySession, function(req, res) {
-    res.json({
-      isValid: req.sessionValid
-    });
+    res.json(req.session);
   });
 
   router.all('/revokesession', sessionMiddleware.revokeSession, function(req, res) {

--- a/lib/mbaas/mbaas-session-middleware.js
+++ b/lib/mbaas/mbaas-session-middleware.js
@@ -47,11 +47,11 @@ function verifySession(req, res, next) {
     return next();
   }
 
-  provider.verifySession(sessionId, function(err, valid) {
+  provider.verifySession(sessionId, function(err, session) {
     if (err) {
       return next(err);
     }
-    req.sessionValid = valid;
+    req.session = session;
     return next();
   });
 }

--- a/lib/mbaas/session/mongoProvider.js
+++ b/lib/mbaas/session/mongoProvider.js
@@ -18,8 +18,9 @@ module.exports = {
       '_id': token
     }, function(err, foundSession) {
       //For the session to be valid, the expiry date must be greater than now.
-      var valid = !err && foundSession &&  new Date() < new Date(foundSession.expires);
-      return cb(err, valid);
+      var valid = !err && foundSession && new Date() < new Date(foundSession.expires);
+      foundSession.isValid = valid;
+      return cb(err, foundSession);
     });
   },
   revokeSession: function(token, cb) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-user",
-  "version": "0.6.5",
+  "version": "0.6.6-pre.805-1",
   "description": "A user module for WFM",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Motivation

Allow users to retrieve current logged user reference (ID) from session. 

## Usage

```
var mbaasApi = require('fh-mbaas-api');
var userSessionApi = require("fh-wfm-user/lib/cloud/sessionApi")(mbaasApi);
  
return userSessionApi.getUserIdForSessionPromise(filter.sessionToken).then(function(userId){
  console.log("userId");
});
```