### PR TITLE
Allow the session expiration length to be configurable

### DIFF
--- a/lib/mbaas/session/mongoProvider.js
+++ b/lib/mbaas/session/mongoProvider.js
@@ -7,7 +7,10 @@ module.exports = {
       if (err) {
         return cb(err);
       }
-      self.store = new MongoStore({db: mongo});
+      self.store = new MongoStore({
+        db: mongo,
+        ttl: expressConfig.config.ttl || 14 * 24 * 60 * 60 // = 14 days. Default
+      });
       self.db = mongo;
       return cb(null);
     });


### PR DESCRIPTION
This will allow the default expiry time to be overwritten e.g.
```var sessionOptions = {
  store: 'mongo',
  config: {
    secret: process.env.FH_COOKIE_SECRET || 'raincatcher',
    resave: false,
    saveUninitialized: true,
    ttl: process.env.SESSION_DURATION || (365 * 24 * 60 * 60), // one year
    cookie: {
      secure: process.env.NODE_ENV === 'production',
      httpOnly: true,
      path: '/',
      maxAge: process.env.COOKIE_MAXAGE || (365 * 24 * 60 * 60 * 1000) // one year
    }
  }
};```
