### PR TITLE
setting the fh.cloud timeout from an env var instead of using the def…

### DIFF
--- a/lib/client/user/user-client.js
+++ b/lib/client/user/user-client.js
@@ -45,7 +45,8 @@ UserClient.prototype.xhr = function(_options) {
   var defaultOptions = {
     path: '/',
     method: 'get',
-    contentType: 'application/json'
+    contentType: 'application/json',
+    timeout: config.clientRequestTimeout
   };
   var options = _.defaults(_options, defaultOptions);
   var deferred = q.defer();

--- a/lib/config/config-user.js
+++ b/lib/config/config-user.js
@@ -8,4 +8,5 @@ module.exports = {
   defaultProfileDataExclusionList: ['password'],
   sessionTokenExpiry: process.env.WFM_TOKEN_EXPIRY || 1800,
   requestTimeout: process.env.WFM_REQUEST_TIMEOUT || 25000
+  clientRequestTimeout: process.env.WFM_CLIENT_REQUEST_TIMEOUT || 25000
 };

--- a/lib/config/config-user.js
+++ b/lib/config/config-user.js
@@ -7,6 +7,6 @@ module.exports = {
   policyId: process.env.WFM_AUTH_POLICY_ID || 'wfm',
   defaultProfileDataExclusionList: ['password'],
   sessionTokenExpiry: process.env.WFM_TOKEN_EXPIRY || 1800,
-  requestTimeout: process.env.WFM_REQUEST_TIMEOUT || 25000
+  requestTimeout: process.env.WFM_REQUEST_TIMEOUT || 25000,
   clientRequestTimeout: process.env.WFM_CLIENT_REQUEST_TIMEOUT || 25000
 };


### PR DESCRIPTION
…ault 1 min.

I think it would be good to have a timeout for the client when sending requests to the cloud, separate to the cloud making requests to services.